### PR TITLE
KVO leak in SVGKImage

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -225,6 +225,8 @@ static NSMutableDictionary* globalSVGKImageCache;
         }
     }
 #endif
+	
+	[self removeObserver:self forKeyPath:@"DOMTree.viewport"];
 
     self.source = nil;
     self.parseErrorsAndWarnings = nil;


### PR DESCRIPTION
Now removing KVO on DOMTree.viewport in dealloc. This is added in initWithParsedSVG and never removed, which causes a leak when an SVGKImage is deallocated.
