### PR TITLE
Fix an SVG parsing hotspot

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */; };
+		036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */; };
 		661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		661ADBF316CC2FBE006F4BC3 /* SVGTextPositioningElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */; };
 		661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -215,6 +217,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+SVGKExtensions.h"; sourceTree = "<group>"; };
+		036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+SVGKExtensions.m"; sourceTree = "<group>"; };
 		661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextPositioningElement.h; sourceTree = "<group>"; };
 		661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGTextPositioningElement.m; sourceTree = "<group>"; };
 		661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextContentElement.h; sourceTree = "<group>"; };
@@ -730,6 +734,8 @@
 		66E863911688C2780059C9C4 /* UIKit additions */ = {
 			isa = PBXGroup;
 			children = (
+				036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */,
+				036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */,
 				66E863921688C2780059C9C4 /* SVGKFastImageView.h */,
 				66E863931688C2780059C9C4 /* SVGKFastImageView.m */,
 				66E863941688C2780059C9C4 /* SVGKImageView.h */,
@@ -867,6 +873,7 @@
 				661ADBFC16CC364F006F4BC3 /* SVGTextPositioningElement_Mutable.h in Headers */,
 				661AE44916D13DA8005E69D9 /* SVGTransformable.h in Headers */,
 				661AE44A16D13DAD005E69D9 /* SVGFitToViewBox.h in Headers */,
+				036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1022,6 +1029,7 @@
 				663FD01516CAEF0D00CCBFB3 /* SVGHelperUtilities.m in Sources */,
 				661ADBF316CC2FBE006F4BC3 /* SVGTextPositioningElement.m in Sources */,
 				661ADBF816CC2FCA006F4BC3 /* SVGTextContentElement.m in Sources */,
+				036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -1,5 +1,7 @@
 #import "SVGKPointsAndPathsParser.h"
 
+#import "NSCharacterSet+SVGKExtensions.h"
+
 // TODO: support quadratic-bezier-curveto
 // TODO: support smooth-quadratic-bezier-curveto
 // TODO: support elliptical-arc
@@ -201,9 +203,7 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
  */
 + (void) readWhitespace:(NSScanner*)scanner
 {
-	
-    NSCharacterSet* whitespace = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"%c%c%c%c", 0x20, 0x9, 0xD, 0xA]];
-    [scanner scanCharactersFromSet:whitespace
+    [scanner scanCharactersFromSet:[NSCharacterSet SVGWhitespaceCharacterSet]
                         intoString:NULL];
 }
 

--- a/Source/UIKit additions/NSCharacterSet+SVGKExtensions.h
+++ b/Source/UIKit additions/NSCharacterSet+SVGKExtensions.h
@@ -1,0 +1,15 @@
+//
+//  NSCharacterSet+SVGKExtensions.h
+//  Avatar
+//
+//  Created by Devin Chalmers on 3/6/13.
+//  Copyright (c) 2013 DJZ. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSCharacterSet (SVGKExtensions)
+
++ (NSCharacterSet *)SVGWhitespaceCharacterSet;
+
+@end

--- a/Source/UIKit additions/NSCharacterSet+SVGKExtensions.m
+++ b/Source/UIKit additions/NSCharacterSet+SVGKExtensions.m
@@ -1,0 +1,27 @@
+//
+//  NSCharacterSet+SVGKExtensions.m
+//  Avatar
+//
+//  Created by Devin Chalmers on 3/6/13.
+//  Copyright (c) 2013 DJZ. All rights reserved.
+//
+
+#import "NSCharacterSet+SVGKExtensions.h"
+
+@implementation NSCharacterSet (SVGKExtensions)
+
+/**
+ wsp:
+ (#x20 | #x9 | #xD | #xA)
+ */
++ (NSCharacterSet *)SVGWhitespaceCharacterSet;
+{
+	static NSCharacterSet *sWhitespaceCharacterSet = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sWhitespaceCharacterSet = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"%c%c%c%c", 0x20, 0x9, 0xD, 0xA]];
+    });
+    return sWhitespaceCharacterSet;
+}
+
+@end


### PR DESCRIPTION
Creating autoreleased objects in tight loops is expensive.
