### PR TITLE
iPhone 5s has the same density as 5 and 4

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -141,7 +141,8 @@ static float cachedDevicePixelsPerInch;
 		return 163.0f;
 	
 	if( [platform hasPrefix:@"iPhone4"]
-	|| [platform hasPrefix:@"iPhone5"])
+	|| [platform hasPrefix:@"iPhone5"]
+    || [platform hasPrefix:@"iPhone6"])
 		return 326.0f;
 	
 	if( [platform hasPrefix:@"iPhone"]) // catch-all for higher-end devices not yet existing


### PR DESCRIPTION
The iPhone 5s (hw.machine values of iPhone6,1 and iPhone6,2) has the same pixel density as the iPhone 5.
This fixes issue #106.
