### PR TITLE
Accommodate new phone platforms

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -141,7 +141,9 @@ static float cachedDevicePixelsPerInch;
 		return 163.0f;
 	
 	if( [platform hasPrefix:@"iPhone4"]
-	|| [platform hasPrefix:@"iPhone5"])
+    || [platform hasPrefix:@"iPhone5"]
+    || [platform hasPrefix:@"iPhone5C"]
+    || [platform hasPrefix:@"iPhone5S"])
 		return 326.0f;
 	
 	if( [platform hasPrefix:@"iPhone"]) // catch-all for higher-end devices not yet existing


### PR DESCRIPTION
On new 5S, this was spewing on startup:

kernel[0] <Debug>: launchd[5001] Container: /private/var/mobile/Applications/AAD2D9D5-168F-4915-892F-6B7D077C727A (sandbox)
Shape Shuffle[5001] <Notice>: TestFlight: Crash Handlers are installed
Shape Shuffle[5001] <Warning>: **\* Assertion failure in +[SVGLength pixelsPerInchForCurrentDevice], /Users/bdalziel/Desktop/SVGKit-1.1.0/Source/DOM classes/SVG-DOM/SVGLength.m:150
Shape Shuffle[5001] <Error>: **\* Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Not supported yet: you are using an iPhone that didn't exist when this code was written, we have no idea what the pixel count per inch is!'
**\* First throw call stack:
(0x30c79e83 0x3b0436c7 0x30c79d55 0x316220af 0x13ad67 0x13a85d 0x3b03f271 0x3b0467cf 0x3b03f02b 0x3b03edf9 0x14674f 0x14b54f 0x14d1a1 0x14e9e9 0x3b3f6227 0x3b3f42b5 0x3b3f3059 0x14c68f 0x14ba49 0x154c8f 0x154e37 0x15436b 0x153eef 0x98285 0x98d6d 0xa2e51 0xa29e9 0xa258d 0x85f27 0x3346eaad 0x3346e4f3 0x33468b41 0x33403a07 0x33402cfd 0x33468321 0x3594c76d 0x3594c357 0x30c44777 0x30c44713 0x30c42edf 0x30bad471 0x30bad253 0x334675c3 0x33462845 0x85d67 0x3b53cab7)
ReportCrash[5003] <Notice>: ReportCrash acting against PID 5001
ReportCrash[5003] <Notice>: Formulating crash report for process Shape Shuffle[5001]
com.apple.launchd[1](UIKitApplication:com.slytrunk.shapeshuffle[0xa6e7][5001]) <Warning>: (UIKitApplication:com.slytrunk.shapeshuffle[0xa6e7]) Job appears to have crashed: Abort trap: 6
backboardd[33] <Warning>: Application 'UIKitApplication:com.slytrunk.shapeshuffle[0xa6e7]' exited abnormally with signal 6: Abort trap: 6

Might only be limited to devices where assertions fatal (internal apple developer devices for example), but worthwhile non the less.
