### PR TITLE
Not include unnecessary files in SVGKImage.h so app can contain only it.

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
@@ -6,6 +6,9 @@
 
 @interface SVGRectElement ()
 
+#ifndef __IPHONE_7_0
+#define __IPHONE_7_0     70000
+#endif
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_7_0
 void CGPathAddRoundedRect (CGMutablePathRef path, CGRect rect, CGFloat radiusX, CGFloat radiusY);
 #endif

--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -37,18 +37,22 @@
 
 #import <UIKit/UIKit.h>
 
-#import "SVGLength.h"
-#import "SVGDocument.h"
-#import "SVGElement.h"
-#import "SVGSVGElement.h"
+//#import "SVGLength.h"
+//#import "SVGDocument.h"
+//#import "SVGElement.h"
+//#import "SVGSVGElement.h"
 
-#import "SVGKParser.h"
-#import "SVGKSource.h"
-#import "SVGKParseResult.h"
+//#import "SVGKParser.h"
+//#import "SVGKSource.h"
+//#import "SVGKParseResult.h"
 
 #define ENABLE_GLOBAL_IMAGE_CACHE_FOR_SVGKIMAGE_IMAGE_NAMED 1 // if ENABLED, then ALL instances created with imageNamed: are shared, and are NEVER RELEASED
 
 @class SVGDefsElement;
+@class SVGKSource;
+@class SVGKParseResult;
+@class SVGDocument;
+@class SVGSVGElement;
 
 @interface SVGKImage : NSObject // doesn't extend UIImage because Apple made UIImage immutable
 {

--- a/Source/Unsorted/SVGKImage+SVGPathView.h
+++ b/Source/Unsorted/SVGKImage+SVGPathView.h
@@ -9,6 +9,7 @@
  */
 
 #import "SVGLayeredElement.h"
+#import "SVGElement.h"
 
 #if NS_BLOCKS_AVAILABLE
 typedef void (^SVGElementAggregationBlock)(SVGElement < SVGLayeredElement > * layeredElement);

--- a/Source/Unsorted/SVGKImage+SVGPathView.m
+++ b/Source/Unsorted/SVGKImage+SVGPathView.m
@@ -1,4 +1,5 @@
 #import "SVGKImage+SVGPathView.h"
+#import "SVGSVGElement.h"
 
 @implementation SVGKImage (SVGPathView)
 


### PR DESCRIPTION
1.  Define __IPHONE_7_0 for iOS 6 to avoid implicit declaration warning about CGPathAddRoundedRect.
2.  Not include unnecessary files in SVGKImage.h so app can contain only it.
