### PR TITLE
Clear SVGKImage cache when app enters background.

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -72,13 +72,14 @@ static NSMutableDictionary* globalSVGKImageCache;
 {
 	if( self == [SVGKImage class]) // Have to protect against subclasses ADDITIONALLY calling this, as a "[super initialize] line
 	{
-		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+		[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningOrBackgroundNotification:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarningOrBackgroundNotification:) name:UIApplicationDidEnterBackgroundNotification object:nil];
 	}
 }
 
-+(void) didReceiveMemoryWarningNotification:(NSNotification*) notification
++(void) didReceiveMemoryWarningOrBackgroundNotification:(NSNotification*) notification
 {
-	DDLogCWarn(@"[%@] Low-mem; purging cache of %i SVGKImage's...", self, [globalSVGKImageCache count] );
+	DDLogCWarn(@"[%@] Low-mem or background; purging cache of %i SVGKImages...", self, [globalSVGKImageCache count] );
 	
 	[globalSVGKImageCache removeAllObjects]; // once they leave the cache, if they are no longer referred to, they should automatically dealloc
 }


### PR DESCRIPTION
I have added code to clear the SVGKImage cache when the app enters background or receives a memory warning. This is useful because an app that consumes less memory, is less likely to be purged from memory while in background.

You could also use NSCache to cache images instead of NSMutableDictionary, which will automatically remove cached objects.
