### PR TITLE
Fixed the demo issue mentioned in pull #124.

### DIFF
--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -51,33 +51,6 @@
     return nil;
 }
 
-- (void)populateFromImage:(SVGKImage*) im
-{
-		internalContextPointerBecauseApplesDemandsIt = @"Apple wrote the addObserver / KVO notification API wrong in the first place and now requires developers to pass around pointers to fake objects to make up for the API deficicineces. You have to have one of these pointers per object, and they have to be internal and private. They serve no real value.";
-	
-#if TEMPORARY_WARNING_FOR_APPLES_BROKEN_RENDERINCONTEXT_METHOD
-		BOOL imageIsGradientFree = [SVGKFastImageView svgImageHasNoGradients:im];
-		if( !imageIsGradientFree )
-			DDLogWarn(@"[%@] WARNING: Apple's rendering DOES NOT ALLOW US to render this image correctly using SVGKFastImageView, because Apple's renderInContext method - according to Apple's docs - ignores Apple's own masking layers. Until Apple fixes this bug, you should use SVGKLayeredImageView for this particular SVG file (or avoid using gradients)", [self class]);
-#endif
-		
-		self.image = im;
-		self.frame = CGRectMake( 0,0, im.size.width, im.size.height ); // NB: this uses the default SVG Viewport; an ImageView can theoretically calc a new viewport (but its hard to get right!)
-		self.tileRatio = CGSizeZero;
-		self.backgroundColor = [UIColor clearColor];
-		
-		/** redraw-observers */
-		if( self.disableAutoRedrawAtHighestResolution )
-			;
-		else
-			[self addInternalRedrawOnResizeObservers];
-		
-		/** other obeservers */
-		[self addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
-		[self addObserver:self forKeyPath:@"tileRatio" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
-		[self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
-}
-
 - (id)initWithCoder:(NSCoder *)aDecoder
 {
 	self = [super initWithCoder:aDecoder];
@@ -100,17 +73,44 @@
 
 - (id)initWithSVGKImage:(SVGKImage*) im
 {
-	if( im == nil )
-	{
-		DDLogWarn(@"[%@] WARNING: you have initialized an SVGKImageView with a blank image (nil). Possibly because you're using Storyboards or NIBs which Apple won't allow us to decorate. Make sure you assign an SVGKImage to the .image property!", [self class]);
-	}
-	
     self = [super init];
     if (self)
 	{
         [self populateFromImage:im];
     }
     return self;
+}
+
+- (void)populateFromImage:(SVGKImage*) im
+{
+	if( im == nil )
+	{
+		DDLogWarn(@"[%@] WARNING: you have initialized an SVGKImageView with a blank image (nil). Possibly because you're using Storyboards or NIBs which Apple won't allow us to decorate. Make sure you assign an SVGKImage to the .image property!", [self class]);
+	}
+    
+    internalContextPointerBecauseApplesDemandsIt = @"Apple wrote the addObserver / KVO notification API wrong in the first place and now requires developers to pass around pointers to fake objects to make up for the API deficicineces. You have to have one of these pointers per object, and they have to be internal and private. They serve no real value.";
+    
+#if TEMPORARY_WARNING_FOR_APPLES_BROKEN_RENDERINCONTEXT_METHOD
+    BOOL imageIsGradientFree = [SVGKFastImageView svgImageHasNoGradients:im];
+    if( !imageIsGradientFree )
+        DDLogWarn(@"[%@] WARNING: Apple's rendering DOES NOT ALLOW US to render this image correctly using SVGKFastImageView, because Apple's renderInContext method - according to Apple's docs - ignores Apple's own masking layers. Until Apple fixes this bug, you should use SVGKLayeredImageView for this particular SVG file (or avoid using gradients)", [self class]);
+#endif
+    
+    self.image = im;
+    self.frame = CGRectMake( 0,0, im.size.width, im.size.height ); // NB: this uses the default SVG Viewport; an ImageView can theoretically calc a new viewport (but its hard to get right!)
+    self.tileRatio = CGSizeZero;
+    self.backgroundColor = [UIColor clearColor];
+    
+    /** redraw-observers */
+    if( self.disableAutoRedrawAtHighestResolution )
+        ;
+    else
+        [self addInternalRedrawOnResizeObservers];
+    
+    /** other obeservers */
+    [self addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
+    [self addObserver:self forKeyPath:@"tileRatio" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
+    [self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
 }
 
 - (void)setImage:(SVGKImage *)image {

--- a/Source/UIKit additions/SVGKLayeredImageView.m
+++ b/Source/UIKit additions/SVGKLayeredImageView.m
@@ -26,10 +26,17 @@
 
 - (id)initWithCoder:(NSCoder *)aDecoder
 {
-    self = [super initWithCoder:aDecoder];
+    if( aDecoder == nil )
+	{
+		self = [super initWithFrame:CGRectMake(0,0,100,100)]; // coincides with the inline SVG in populateFromImage!
+	}
+	else
+	{
+		self = [super initWithCoder:aDecoder];
+	}
     if( self )
     {
-        self.backgroundColor = [UIColor clearColor];
+        [self populateFromImage:nil];
     }
 	return self;
 }
@@ -48,17 +55,32 @@
 {
 	if( im == nil )
 	{
+		self = [super initWithFrame:CGRectMake(0,0,100,100)]; // coincides with the inline SVG in populateFromImage!
+	}
+	else
+	{
+		self = [super initWithFrame:CGRectMake( 0,0, im.CALayerTree.frame.size.width, im.CALayerTree.frame.size.height )]; // default: 0,0 to width x height of original image];
+	}
+    
+    if (self)
+    {
+        [self populateFromImage:im];
+    }
+    return self;
+}
+
+- (void)populateFromImage:(SVGKImage*) im
+{
+	if( im == nil )
+	{
 		DDLogWarn(@"[%@] WARNING: you have initialized an [%@] with a blank image (nil). Possibly because you're using Storyboards or NIBs which Apple won't allow us to decorate. Make sure you assign an SVGKImage to the .image property!", [self class], [self class]);
 		
-		self = [super initWithFrame:CGRectMake(0,0,100,100)]; // coincides with the inline SVG below!
-		if( self )
-		{
-			self.backgroundColor = [UIColor clearColor];
-			
+		self.backgroundColor = [UIColor clearColor];
+        
 /**
  ************* NB: it is critical that the string we're about to create is NOT INDENTED - the tabs would break the parsing!
  */
-			NSString* svgStringDefaultContents = @"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n\
+		NSString* svgStringDefaultContents = @"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n\
 \n\
 <svg \
 xmlns:svg=\"http://www.w3.org/2000/svg\" \
@@ -106,29 +128,21 @@ y=\"1030.2456\" \
 style=\"font-size:24px;fill:#fffc45;fill-opacity:1\">SVG</tspan></text> \
 </g> \
 </svg>";
-			
-			NSLog(@"About to make a blank image using the inlined SVG = %@", svgStringDefaultContents);
-			
-			SVGKImage* defaultBlankImage = [SVGKImage imageWithSource:[SVGKSourceString sourceFromContentsOfString:svgStringDefaultContents]];
-			
-			self.backgroundColor = [UIColor cyanColor];
-			
-			((SVGKLayer*) self.layer).SVGImage = defaultBlankImage;
-		}
+        
+		NSLog(@"About to make a blank image using the inlined SVG = %@", svgStringDefaultContents);
+		
+		SVGKImage* defaultBlankImage = [SVGKImage imageWithSource:[SVGKSourceString sourceFromContentsOfString:svgStringDefaultContents]];
+		
+		self.backgroundColor = [UIColor cyanColor];
+		
+		((SVGKLayer*) self.layer).SVGImage = defaultBlankImage;
 	}
 	else
 	{
-		self = [super initWithFrame:CGRectMake( 0,0, im.CALayerTree.frame.size.width, im.CALayerTree.frame.size.height )]; // default: 0,0 to width x height of original image];
-		if (self)
-		{
-			self.backgroundColor = [UIColor clearColor];
-			
-			((SVGKLayer*) self.layer).SVGImage = im;
-			
-		}
+		self.backgroundColor = [UIColor clearColor];
+		
+		((SVGKLayer*) self.layer).SVGImage = im;
 	}
-	
-    return self;
 }
 
 /** Delegate the call to the internal layer that's coded to handle this stuff automatically */


### PR DESCRIPTION
I'd tend to argue that the demo should be calling initWithSVGKImage with a nil image instead of initWithCoder with a nil coder, but regardless this encouraged me to clean up populateFromImage in both kinds of SVGKImageViews.
