### PR TITLE
Skipping cache purge and log message when cache is empty

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -81,6 +81,8 @@ static NSMutableDictionary* globalSVGKImageCache;
 
 +(void) didReceiveMemoryWarningOrBackgroundNotification:(NSNotification*) notification
 {
+	if ([globalSVGKImageCache count] == 0) return;
+	
 	DDLogCWarn(@"[%@] Low-mem or background; purging cache of %i SVGKImages...", self, [globalSVGKImageCache count] );
 	
 	[globalSVGKImageCache removeAllObjects]; // once they leave the cache, if they are no longer referred to, they should automatically dealloc


### PR DESCRIPTION
The warning message can be misleading at first when theres nothing actually purging. Also, shouldn't need to call removeAll when its already empty.

Resubmitting to the 1.x branch from pull request #110
