### PR TITLE
Adding podspec pointing to 1.x

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -1,0 +1,25 @@
+Pod::Spec.new do |s|
+  s.name        = 'SVGKit'
+  s.version     = '1.x'
+  s.license     = 'MIT'
+  s.platform    = :ios, '7.0'
+  s.summary     = "Display and interact with SVG Images on iOS, using native rendering (CoreAnimation)."
+  s.homepage = 'https://github.com/SVGKit/SVGKit'
+  s.author   = { 'Steven Fusco'    => 'github@stevenfusco.com',
+                 'adam'            => 'git.sucks.this.email.doesnt.exist@mailinator.com',
+                 'adamgit'         => 'adam.m.s.martin@gmail.com',
+                 'Kevin Stich'     => 'stich@50cubes.com',
+                 'Joshua May'      => 'notjosh@gmail.com',
+                 'Eric Man'        => 'meric.au@gmail.com',
+                 'adamgit'         => 'git.sucks.this.email.doesnt.exist@mailinator.com',
+                 'Matt Rajca'      => 'matt.rajca@me.com',
+                 'Moritz Pfeiffer' => 'moritz.pfeiffer@alp-phone.ch',
+                 'Steven Fusco'    => 'sfusco@spiral.local',
+                 'Eric Man'        => 'Eric@eric-mans-macbook-2.local' }
+  s.source   = { :git => 'https://github.com/SVGKit/SVGKit.git', :branch => "1.x" }
+
+  s.ios.source_files = 'Source/*{.h,m}', 'Source/**/*.{h,m}'
+  s.libraries = 'xml2'
+  s.framework = 'QuartzCore', 'CoreText'
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+end


### PR DESCRIPTION
With this, CocoaPods users would be able to target `1.x` in their Podfile with the following line:

```
pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git'
```

However, 1.x in it's current state does't compile with the current podspec.  An example project (with SVGKit already added) can be found here: https://github.com/pyro2927/SVGKitPodExample.
