### PR TITLE
Fix unrecognized selector issue in [NS.. SVGWhitespaceCharacterSet].

### DIFF
--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -196,8 +196,21 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
  */
 + (void) readWhitespace:(NSScanner*)scanner
 {
-    [scanner scanCharactersFromSet:[NSCharacterSet SVGWhitespaceCharacterSet]
+    [scanner scanCharactersFromSet:[SVGKPointsAndPathsParser SVGWhitespaceCharacterSet]
                         intoString:NULL];
+}
+
++ (NSCharacterSet *)SVGWhitespaceCharacterSet;
+{
+	static NSCharacterSet *sWhitespaceCharacterSet = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+		DDLogVerbose(@"Allocating static NSCharacterSet containing whitespace characters. Should be small, but Apple seems to take up 5+ megabytes each time?");
+		sWhitespaceCharacterSet = [NSCharacterSet characterSetWithCharactersInString:[NSString stringWithFormat:@"%c%c%c%c", 0x20, 0x9, 0xD, 0xA]];
+		[sWhitespaceCharacterSet retain]; // required, this is a non-ARC project.
+    });
+	
+    return sWhitespaceCharacterSet;
 }
 
 + (void) readCommaAndWhitespace:(NSScanner*)scanner


### PR DESCRIPTION
The issue can be found in [TouchVG](https://github.com/rhcad/touchvg)'s TestView-SVG project:
TestView-SVG[3660:60b] +[NSCharacterSet SVGWhitespaceCharacterSet]: unrecognized selector sent to class 0x39e43da0

The build and reappear way of [TouchVG](https://github.com/rhcad/TouchVG) (if you need it):
1. Check out TouchVG project containing [TouchVGCore](https://github.com/rhcad/TouchVGCore) and SVGKit submodules.
2. 'cd' to the 'ios' directory containing the file of 'build.sh', then type `./build.sh` to compile libraries.
3. Run TestView-SVG target.
4. Tap `GiPaintView SVG images` row, then the issue occurs.
`2014-02-05 00:50:33.655 TestView-SVG[40639:70b] +[NSCharacterSet SVGWhitespaceCharacterSet]: unrecognized selector sent to class 0x17f0ff0
2014-02-05 00:50:33.655 TestView-SVG[40639:70b] Fail to parse fonts.svg due to NSInvalidArgumentException`
