### PR TITLE
Updated podspec so it will actually build when added as a pod to a project

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -18,8 +18,10 @@ Pod::Spec.new do |s|
                  'Eric Man'        => 'Eric@eric-mans-macbook-2.local' }
   s.source   = { :git => 'https://github.com/SVGKit/SVGKit.git', :branch => "1.x" }
 
-  s.ios.source_files = 'Source/*{.h,m}', 'Source/**/*.{h,m}'
+  s.ios.source_files = 'Source/*{.h,m}', 'Source/DOM classes/**/*.{h,m}', 'Source/Exporters/*.{h,m}', 'Source/Parsers/**/*.{h,m}', 'Source/QuartzCore additions/**/*.{h,m}', 'Source/Sources/**/*.{h,m}', 'Source/UIKit additions/**/*.{h,m}', 'Source/Unsorted/**/*.{h,m}'
   s.libraries = 'xml2'
   s.framework = 'QuartzCore', 'CoreText'
+  s.dependency 'CocoaLumberjack'
+  s.prefix_header_file = 'XCodeProjectData/SVGKit-iOS/SVGKit-iOS-Prefix.pch'
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
 end


### PR DESCRIPTION
With these changes users can use `pod 'SVGKit', :git => 'https://github.com/SVGKit/SVGKit.git'` to install SVGKit as a Cocoapod. Ideally we would replace the outdated v1.0 that is in the Cocoapods spec repo, but to do that you would have to transition to tagging releases, the podspec works as is but it does throw a warning that it is just pointing to the 1.x branch instead of a tag. The Cocoapod's team doesn't accept pod specs with warnings.

Going forward on development with SVGKit here are a couple things to be aware of. 
1) If you add any new source files outside the current directory structure or add new sub directories you will need to update the pod spec's `s.ios.source_files` to include that path. 
2) CocoaLumberjack will be included as a dependency. This means it will use the latest published CocoaLumberjack version, and not the version you have been including in the project so far. This fixes cases where people add SVGKit to their app and they have a conflict since their app or another lib it uses had also included CocoaLumberjack.
