### PR TITLE
fix memory leak of NSDates

### DIFF
--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -185,6 +185,8 @@
 	[self removeObserver:self forKeyPath:@"showBorder" context:internalContextPointerBecauseApplesDemandsIt];
     
 	self.image = nil;
+    self.startRenderTime = nil;
+    self.endRenderTime = nil;
 	
     [super dealloc];
 }


### PR DESCRIPTION
Loading any svg file into a SVGKFastImageView shows leaks of 2 NSDate objects from SVGKFastImageView when leak profiling in Instruments.  This change resolves those leaks.
