### PR TITLE
add populateFromImage in initWithFrame method

### DIFF
--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -73,6 +73,7 @@
 	if( self )
 	{
 		self.backgroundColor = [UIColor clearColor];
+		[self populateFromImage:nil];
 	}
 	return self;
 }


### PR DESCRIPTION
when you init it with initWithFrame method you get a observer error for key path layer because you never add a observer. I copied the call from initWithCoder. I think that should be the same behavior.
