### PR TITLE
Change the public headers path to allow zero-config #import <SVGKit/SVGKit.h>

### DIFF
--- a/Demo-iOS.xcodeproj/project.pbxproj
+++ b/Demo-iOS.xcodeproj/project.pbxproj
@@ -538,10 +538,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"../../iOS/**",
-					"../../Core/**",
-				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -564,10 +560,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"../../iOS/**",
-					"../../Core/**",
-				);
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
@@ -581,13 +573,8 @@
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XCodeProjectData/Demo-iOS/Demo-iOS-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"Source/**",
-					"calayer-exporter",
-				);
 				INFOPLIST_FILE = "XCodeProjectData/Demo-iOS/Demo-iOS-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "Demo-iOS";
 				WRAPPER_EXTENSION = app;
@@ -599,13 +586,8 @@
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XCodeProjectData/Demo-iOS/Demo-iOS-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"Source/**",
-					"calayer-exporter",
-				);
 				INFOPLIST_FILE = "XCodeProjectData/Demo-iOS/Demo-iOS-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "Demo-iOS";
 				WRAPPER_EXTENSION = app;

--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -1215,7 +1215,6 @@
 		6639619A16145D0400E58CCA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1242,7 +1241,6 @@
 		6639619B16145D0400E58CCA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -1276,6 +1274,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME).${DYLIB_CURRENT_VERSION}";
+				PUBLIC_HEADERS_FOLDER_PATH = include/SVGKit;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -1296,6 +1295,7 @@
 				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME).${DYLIB_CURRENT_VERSION}";
+				PUBLIC_HEADERS_FOLDER_PATH = include/SVGKit;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/XCodeProjectData/Demo-iOS/DetailViewController.h
+++ b/XCodeProjectData/Demo-iOS/DetailViewController.h
@@ -8,9 +8,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import "SVGKit.h"
-#import "CALayerExporter.h"
-#import "SVGKImage.h"
+#import <SVGKit/SVGKit.h>
+#import <SVGKit/CALayerExporter.h>
+#import <SVGKit/SVGKImage.h>
 
 #define LOAD_SYNCHRONOUSLY 0 // Synchronous load is less code, easier to write - but poor for large images
 

--- a/XCodeProjectData/Demo-iOS/DetailViewController.m
+++ b/XCodeProjectData/Demo-iOS/DetailViewController.m
@@ -9,10 +9,10 @@
 
 #import "MasterViewController.h"
 
-#import "NodeList+Mutable.h"
+#import <SVGKit/NodeList+Mutable.h>
 
-#import "SVGKFastImageView.h"
-#import "SVGKLayeredImageView.h"
+#import <SVGKit/SVGKFastImageView.h>
+#import <SVGKit/SVGKLayeredImageView.h>
 
 @interface ImageLoadingOptions : NSObject
 @property(nonatomic) BOOL requiresLayeredImageView;


### PR DESCRIPTION
Currently to use SVGKit in my iOS project I need to set up custom User Header Search Paths in Xcode to point to the Source folder in the SVGKit project. This pull request changes the location of the public headers that SVGKit generates to allow importing projects to import SVGKit headers using `#import &lt;SVGKit/SVGKit.h&gt;` without the need to set up any User Header Search Paths. It also changes the demo project accordingly.
