### PR TITLE
With 2.0.0 beta of cocoa lumberjack it failed

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Source/*{.h,m}', 'Source/DOM classes/**/*.{h,m}', 'Source/Exporters/*.{h,m}', 'Source/Parsers/**/*.{h,m}', 'Source/QuartzCore additions/**/*.{h,m}', 'Source/Sources/**/*.{h,m}', 'Source/UIKit additions/**/*.{h,m}', 'Source/Unsorted/**/*.{h,m}'
   s.libraries = 'xml2'
   s.framework = 'QuartzCore', 'CoreText'
-  s.dependency 'CocoaLumberjack'
+  s.dependency 'CocoaLumberjack', '~> 1.0'
   s.prefix_header_file = 'XCodeProjectData/SVGKit-iOS/SVGKit-iOS-Prefix.pch'
   s.requires_arc = false
   s.xcconfig = {


### PR DESCRIPTION
I've changed that because with 2.0.0 beta of cocoa lumberjack it failed. If you do not use cocoa lumberjack in your app it will always pull the 2.0.0 beta if , '~> 1.0' is not in the podspec file
