### PR TITLE
Change to not render blocky text on retina displays on iOS

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -136,6 +136,9 @@
     label.string = effectiveText;
     label.alignmentMode = kCAAlignmentLeft;
     label.foregroundColor = [UIColor blackColor].CGColor;
+#if TARGET_OS_IPHONE
+    label.contentsScale = [[UIScreen mainScreen] scale];
+#endif
 
 	/** VERY USEFUL when trying to debug text issues:
 	label.backgroundColor = [UIColor colorWithRed:0.5 green:0 blue:0 alpha:0.5].CGColor;


### PR DESCRIPTION
CATextLayer is [known for rendering blocky text on retina displays](http://stackoverflow.com/questions/5538394/vector-like-drawing-for-zoomable-uiscrollview). The fix is to set its contentsScale to match the screen's scale.

Note that we can't easily do the same for retina on OSX because the layer [may be rendering on a screen with different resolution than the main screen](http://blog.mazaheri.me/post/65931558994/cocoa-please-never-draw-your-nsview-nscell-and).
