### PR TITLE
Stroke dasharray

### DIFF
--- a/Demo-Samples/SVG/test-stroke-dash-array.svg
+++ b/Demo-Samples/SVG/test-stroke-dash-array.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="300"
+   height="200"
+   id="svg2"
+   version="1.1">
+  <g id="layer1">
+    <rect
+      style="fill:none;stroke:#000000;stroke-width:3;"
+      stroke-dasharray="4,2,6,5"
+      id="rect3012"
+      width="260"
+      height="160"
+      x="20"
+      y="20" />  
+    </g>
+</svg>

--- a/Demo-Samples/Sample Licenses.txt
+++ b/Demo-Samples/Sample Licenses.txt
@@ -41,7 +41,11 @@ map-alaska-onlysimple.svg
 test-wave-1.svg
      -- Public Domain, author: Adam Martin (http://t-machine.org)
      -- Created by: Inkscape
-	 
+     
+test-stroke-dash-array.svg
+     -- Public Domain, author: David Sweetman
+     -- Created by author
+
 Location_European_nation_states
      -- Creative Commons
 	 -- http://en.wikipedia.org/wiki/File:Location_European_nation_states.svg

--- a/Demo-iOS.xcodeproj/project.pbxproj
+++ b/Demo-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		556C405119A5122800733CBB /* test-stroke-dash-array.svg in Resources */ = {isa = PBXBuildFile; fileRef = 556C405019A5122800733CBB /* test-stroke-dash-array.svg */; };
 		661A0DCF161727CF008D5FBE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661A0DCE161727CF008D5FBE /* UIKit.framework */; };
 		661A0DD1161727CF008D5FBE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661A0DD0161727CF008D5FBE /* Foundation.framework */; };
 		661A0DD3161727CF008D5FBE /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 661A0DD2161727CF008D5FBE /* CoreGraphics.framework */; };
@@ -94,6 +95,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		556C405019A5122800733CBB /* test-stroke-dash-array.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "test-stroke-dash-array.svg"; sourceTree = "<group>"; };
 		661A0DCA161727CF008D5FBE /* Demo-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Demo-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		661A0DCE161727CF008D5FBE /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		661A0DD0161727CF008D5FBE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -332,6 +334,7 @@
 				66E785AA171A228A001EF59D /* svg-with-explicit-width.svg */,
 				66E785AC171A2345001EF59D /* svg-with-explicit-width-large.svg */,
 				66E8628A1688BA510059C9C4 /* test-wave-1.svg */,
+				556C405019A5122800733CBB /* test-stroke-dash-array.svg */,
 				66E8628B1688BA510059C9C4 /* Text.svg */,
 				66E8628C1688BA510059C9C4 /* uk-only.svg */,
 				66E8628D1688BA510059C9C4 /* voies.svg */,
@@ -424,6 +427,7 @@
 				66E862921688BA510059C9C4 /* Blank_Map-Africa.svg in Resources */,
 				66E862931688BA510059C9C4 /* breaking-1.svg in Resources */,
 				66E862941688BA510059C9C4 /* CurvedDiamond.svg in Resources */,
+				556C405119A5122800733CBB /* test-stroke-dash-array.svg in Resources */,
 				66E862951688BA510059C9C4 /* Europe_states_reduced.svg in Resources */,
 				66E862961688BA510059C9C4 /* imageWithASinglePointPath.svg in Resources */,
 				66E862971688BA510059C9C4 /* Lion.svg in Resources */,

--- a/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
+++ b/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
@@ -71,7 +71,10 @@
 	for (size_t n = 0; n <= len; n++) {
 		char c = cstr[n];
 		
-		if (c == '\n' || c == '\t' || c == ' ') {
+        /* SVG spec specifies some attribute lists might be delimited by white space.
+         e.g. stroke-dasharray is 'A list of comma and/or white space separated <length>s'
+         http://www.w3.org/TR/SVG/painting.html */
+		if (c == '\n' || c == '\t') {
 			continue;
 		}
 		

--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -366,6 +366,33 @@
 		
 		_shapeLayer.strokeColor = CGColorWithSVGColor( strokeColorAsSVGColor );
 		
+        /**
+         Stroke dash array
+         */
+        NSString *dashArrayString = [svgElement cascadedValueForStylableProperty:@"stroke-dasharray"];
+        if(dashArrayString != nil && ![dashArrayString isEqualToString:@""]) {
+            NSArray *dashArrayStringComponents = [dashArrayString componentsSeparatedByString:@" "];
+            if( [dashArrayStringComponents count] < 2 )
+            { // min 2 elements required, perhaps it's comma-separated:
+                dashArrayStringComponents = [dashArrayString componentsSeparatedByString:@","];
+            }
+            if( [dashArrayStringComponents count] > 1 )
+            {
+                BOOL valid = NO;
+                NSMutableArray *dashArray = [[NSMutableArray alloc] init];
+                for( NSString *n in dashArrayStringComponents ){
+                    [dashArray addObject:[NSNumber numberWithFloat:[n floatValue]]];
+                    if( !valid && [n floatValue] != 0 ){
+                        // avoid 'CGContextSetLineDash: invalid dash array: at least one element must be non-zero.'
+                        valid = YES;
+                    }
+                }
+                if( valid ){
+                    _shapeLayer.lineDashPattern = dashArray;
+                }
+            }
+        }
+		
 		/**
 		 Line joins + caps: butt / square / miter
 		 */

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -166,7 +166,10 @@
 	if( [[self getAttribute:@"viewBox"] length] > 0 )
 	{
 		NSArray* boxElements = [[self getAttribute:@"viewBox"] componentsSeparatedByString:@" "];
-		
+		if ([boxElements count] < 2) {
+            /* count should be 4 -- maybe they're comma separated like (x,y,w,h) */
+            boxElements = [[self getAttribute:@"viewBox"] componentsSeparatedByString:@","];
+        }
 		_viewBox = SVGRectMake([[boxElements objectAtIndex:0] floatValue], [[boxElements objectAtIndex:1] floatValue], [[boxElements objectAtIndex:2] floatValue], [[boxElements objectAtIndex:3] floatValue]);
 	}
 	else

--- a/XCodeProjectData/Demo-iOS/MasterViewController.m
+++ b/XCodeProjectData/Demo-iOS/MasterViewController.m
@@ -19,28 +19,23 @@
 @synthesize detailViewController = _detailViewController;
 @synthesize nameOfBrokenSVGToLoad = _nameOfBrokenSVGToLoad;
 
-- (id)init
+- (void)setupSampleNames
 {
-    if (self) {
-        self.sampleNames = [NSMutableArray arrayWithObjects: @"map-alaska-onlysimple", @"g-element-applies-rotation", @"groups-and-layers-test", @"http://upload.wikimedia.org/wikipedia/commons/f/f9/BlankMap-Africa.svg", @"shapes", @"strokes", @"transformations", @"rounded-rects", @"gradients",@"radialGradientTest", @"PreserveAspectRatio", @"australia_states_blank", @"Reinel_compass_rose", @"Monkey", @"Blank_Map-Africa", @"opacity01", @"Note", @"Note@2x", @"imageWithASinglePointPath", @"Lion", @"lingrad01", @"Map", @"CurvedDiamond", @"Text", @"text01", @"tspan01", @"Location_European_nation_states", @"uk-only", @"Europe_states_reduced", @"Compass_rose_pale", @"quad01", @"cubic01", @"rotated-and-skewed-text", @"RainbowWing", @"sakamura-default-fill-opacity-test", @"StyleAttribute", @"voies", @"nil-demo-layered-imageview", @"svg-with-explicit-width", @"svg-with-explicit-width-large", @"svg-with-explicit-width-large@160x240", @"BlankMap-World6-Equirectangular", @"Coins", @"imagetag-layered", @"ImageAspectRatio", nil];
-    }
-	
-	/** Apple really sucks. They keep randomly changing which init methods they call, BREAKING ALL EXISTING CODE */
-    return nil;
+    self.sampleNames = [NSMutableArray arrayWithObjects: @"map-alaska-onlysimple", @"g-element-applies-rotation", @"groups-and-layers-test", @"http://upload.wikimedia.org/wikipedia/commons/f/f9/BlankMap-Africa.svg", @"shapes", @"strokes", @"transformations", @"rounded-rects", @"gradients",@"radialGradientTest", @"PreserveAspectRatio", @"australia_states_blank", @"Reinel_compass_rose", @"Monkey", @"Blank_Map-Africa", @"opacity01", @"Note", @"Note@2x", @"imageWithASinglePointPath", @"Lion", @"lingrad01", @"Map", @"CurvedDiamond", @"Text", @"text01", @"tspan01", @"Location_European_nation_states", @"uk-only", @"Europe_states_reduced", @"Compass_rose_pale", @"quad01", @"cubic01", @"rotated-and-skewed-text", @"RainbowWing", @"sakamura-default-fill-opacity-test", @"StyleAttribute", @"voies", @"nil-demo-layered-imageview", @"svg-with-explicit-width", @"svg-with-explicit-width-large", @"svg-with-explicit-width-large@160x240", @"BlankMap-World6-Equirectangular", @"Coins", @"imagetag-layered", @"ImageAspectRatio", @"test-stroke-dash-array", nil];
 }
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
-		[self init];
+		[self setupSampleNames];
     }
     return self;
 }
 - (id)initWithCoder:(NSCoder *)aDecoder {
 	self = [super initWithCoder:aDecoder];
 	if (self) {
-		[self init];
+		[self setupSampleNames];
 	}
 	return self;
 }
@@ -110,9 +105,8 @@
 
 -(void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
 {
-	if( buttonIndex == 0 )
+	if( buttonIndex == [alertView cancelButtonIndex] )
 	{
-		NSLog(@"[%@] Apple hates all developers. Why did they have a 'cancel clicked' if they also send 'cancel' as 'not cancelled'?", [self class]);
 		return;
 	}
 	


### PR DESCRIPTION
Adds support for stroke-dasharray attribute on shapes. I've also added a test SVG file and added it to the demo app.

In addition, the SVG spec specifies that stroke-dasharray might be white space delimited, but the current code smushes the values together, so stroke-dasharray="4 2 8 7" would become one value, 4287. 9d644b0 fixes this issue, and is applied in a separate commit in case it should not be included for some reason. 

I did notice that the test file "London_European_nation_states.svg" defines some `stroke-dasharray`s, but does not appear to render them. It looks like it also defines many `stroke-dasharray:none;`, and cascadedValueForStylableProperty:@"stroke-dasharray" never returns a value other than 'none', so my  hunch is it is still rendering correctly, and the input SVG is not clean.
