### PR TITLE
Improvements to SVGTextElement to support text-anchor and fill, plus a better vertical offset.

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.h
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.h
@@ -50,6 +50,8 @@ This method ONLY looks at current node to establish the above two things, to do 
 
 +(CALayer *) newCALayerForPathBasedSVGElement:(SVGElement*) svgElement withPath:(CGPathRef) path;
 
++(CGColorRef) parseFillForElement:(SVGElement *)svgElement;
+
 +(void) parsePreserveAspectRatioFor:(id<SVGFitToViewBox>) element;
 
 @end

--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -435,14 +435,9 @@
 		}
 	}
 	
-	
 	NSString* actualFill = [svgElement cascadedValueForStylableProperty:@"fill"];
 	NSString* actualFillOpacity = [svgElement cascadedValueForStylableProperty:@"fill-opacity"];
-	if ( [actualFill hasPrefix:@"none"])
-	{
-		_shapeLayer.fillColor = nil;
-	}
-	else if ( [actualFill hasPrefix:@"url"] )
+	if ( [actualFill hasPrefix:@"url"] )
 	{
 		NSRange idKeyRange = NSMakeRange(5, actualFill.length - 6);
 		NSString* _fillId = [actualFill substringWithRange:idKeyRange];
@@ -454,7 +449,7 @@
 		SVGGradientElement* svgGradient = (SVGGradientElement*) [svgElement.rootOfCurrentDocumentFragment getElementById:_fillId];
 		NSAssert( svgGradient != nil, @"This SVG shape has a URL fill (%@), but could not find an XML Node with that ID inside the DOM tree (suggests the parser failed, or the SVG file is corrupt)", _fillId );
 		
-		//if( _shapeLayer != nil && svgGradient != nil ) //this nil check here is distrubing but blocking
+		//if( layer != nil && svgGradient != nil ) //this nil check here is distrubing but blocking
 		{
 			SVGGradientLayer *gradientLayer = [svgGradient newGradientLayerForObjectRect:_shapeLayer.frame viewportRect:svgElement.rootOfCurrentDocumentFragment.viewBox];
 			
@@ -469,6 +464,31 @@
 	}
 	else if( actualFill.length > 0 || actualFillOpacity.length > 0 )
 	{
+		_shapeLayer.fillColor = [self parseFillForElement:svgElement fromFill:actualFill andOpacity:actualFillOpacity];
+	}
+    
+	NSString* actualOpacity = [svgElement cascadedValueForStylableProperty:@"opacity"];
+	_shapeLayer.opacity = actualOpacity.length > 0 ? [actualOpacity floatValue] : 1; // unusually, the "opacity" attribute defaults to 1, not 0
+	CGPathRelease(pathToPlaceInLayer);
+	return _shapeLayer;
+}
+
++(CGColorRef) parseFillForElement:(SVGElement *)svgElement
+{
+	NSString* actualFill = [svgElement cascadedValueForStylableProperty:@"fill"];
+	NSString* actualFillOpacity = [svgElement cascadedValueForStylableProperty:@"fill-opacity"];
+	return [self parseFillForElement:svgElement fromFill:actualFill andOpacity:actualFillOpacity];
+}
+
++(CGColorRef) parseFillForElement:(SVGElement *)svgElement fromFill:(NSString *)actualFill andOpacity:(NSString *)actualFillOpacity
+{
+	CGColorRef fillColor = nil;
+	if ( [actualFill hasPrefix:@"none"])
+	{
+		fillColor = nil;
+	}
+	else if( actualFill.length > 0 || actualFillOpacity.length > 0 )
+	{
 		SVGColor fillColorAsSVGColor = ( actualFill.length > 0 ) ?
 		SVGColorFromString([actualFill UTF8String]) // have to use the intermediate of an SVGColor so that we can over-ride the ALPHA component in next line
 		: SVGColorMake(0, 0, 0, 0);
@@ -476,17 +496,18 @@
         if( actualFillOpacity.length > 0 )
             fillColorAsSVGColor.a = (uint8_t) ([actualFillOpacity floatValue] * 0xFF);
 		
-        _shapeLayer.fillColor = CGColorWithSVGColor(fillColorAsSVGColor);
+        fillColor = CGColorWithSVGColor(fillColorAsSVGColor);
 	}
 	else
 	{
-		
+#if TARGET_OS_IPHONE
+		fillColor = [UIColor blackColor].CGColor;
+#else
+		fillColor = CGColorGetConstantColor(kCGColorBlack);
+#endif
 	}
-    
-	NSString* actualOpacity = [svgElement cascadedValueForStylableProperty:@"opacity"];
-	_shapeLayer.opacity = actualOpacity.length > 0 ? [actualOpacity floatValue] : 1; // unusually, the "opacity" attribute defaults to 1, not 0
-	CGPathRelease(pathToPlaceInLayer);
-	return _shapeLayer;
+
+	return fillColor;
 }
 
 +(void) parsePreserveAspectRatioFor:(id<SVGFitToViewBox>) element

--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -449,7 +449,7 @@
 		SVGGradientElement* svgGradient = (SVGGradientElement*) [svgElement.rootOfCurrentDocumentFragment getElementById:_fillId];
 		NSAssert( svgGradient != nil, @"This SVG shape has a URL fill (%@), but could not find an XML Node with that ID inside the DOM tree (suggests the parser failed, or the SVG file is corrupt)", _fillId );
 		
-		//if( layer != nil && svgGradient != nil ) //this nil check here is distrubing but blocking
+		//if( _shapeLayer != nil && svgGradient != nil ) //this nil check here is distrubing but blocking
 		{
 			SVGGradientLayer *gradientLayer = [svgGradient newGradientLayerForObjectRect:_shapeLayer.frame viewportRect:svgElement.rootOfCurrentDocumentFragment.viewBox];
 			

--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -127,9 +127,6 @@
 	 If/when Apple fixes their bugs - or if you know enough about their API's to workaround the bugs, feel free to fix this code.
 	 */
 	CGFloat offsetToConvertSVGOriginToAppleOrigin = - suggestedUntransformedSize.height;
-#if TARGET_OS_IPHONE
-    offsetToConvertSVGOriginToAppleOrigin /= [[UIScreen mainScreen] scale];
-#endif
 	CGSize fakeSizeToApplyNonTranslatingPartsOfTransform = CGSizeMake( 0, offsetToConvertSVGOriginToAppleOrigin);
 	
 	label.position = CGPointMake( 0,

--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -126,7 +126,11 @@
 	 
 	 If/when Apple fixes their bugs - or if you know enough about their API's to workaround the bugs, feel free to fix this code.
 	 */
-	CGFloat offsetToConvertSVGOriginToAppleOrigin = - suggestedUntransformedSize.height;
+    CTLineRef line = CTLineCreateWithAttributedString( (CFMutableAttributedStringRef) tempString );
+    CGFloat ascent = 0;
+    CTLineGetTypographicBounds(line, &ascent, NULL, NULL);
+    CFRelease(line);
+	CGFloat offsetToConvertSVGOriginToAppleOrigin = -ascent;
 	CGSize fakeSizeToApplyNonTranslatingPartsOfTransform = CGSizeMake( 0, offsetToConvertSVGOriginToAppleOrigin);
 	
 	label.position = CGPointMake( 0,

--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -9,6 +9,7 @@
 #import "SVGElement_ForParser.h" // to resolve Xcode circular dependencies; in long term, parsing SHOULD NOT HAPPEN inside any class whose name starts "SVG" (because those are reserved classes for the SVG Spec)
 
 #import "SVGHelperUtilities.h"
+#import "SVGUtils.h"
 
 @implementation SVGTextElement
 
@@ -126,16 +127,28 @@
 	 If/when Apple fixes their bugs - or if you know enough about their API's to workaround the bugs, feel free to fix this code.
 	 */
 	CGFloat offsetToConvertSVGOriginToAppleOrigin = - suggestedUntransformedSize.height;
+#if TARGET_OS_IPHONE
+    offsetToConvertSVGOriginToAppleOrigin /= [[UIScreen mainScreen] scale];
+#endif
 	CGSize fakeSizeToApplyNonTranslatingPartsOfTransform = CGSizeMake( 0, offsetToConvertSVGOriginToAppleOrigin);
 	
 	label.position = CGPointMake( 0,
 								 0 + CGSizeApplyAffineTransform( fakeSizeToApplyNonTranslatingPartsOfTransform, textTransformAbsoluteWithLocalPositionOffset).height);
-	label.anchorPoint = CGPointZero; // WARNING: SVG applies transforms around the top-left as origin, whereas Apple defaults to center as origin, so we tell Apple to work "like SVG" here.
+    
+    NSString *textAnchor = [self cascadedValueForStylableProperty:@"text-anchor"];
+    if( [@"middle" isEqualToString:textAnchor] )
+        label.anchorPoint = CGPointMake(0.5, 0.0);
+    else if( [@"end" isEqualToString:textAnchor] )
+        label.anchorPoint = CGPointMake(1.0, 0.0);
+    else
+        label.anchorPoint = CGPointZero; // WARNING: SVG applies transforms around the top-left as origin, whereas Apple defaults to center as origin, so we tell Apple to work "like SVG" here.
+    
 	label.affineTransform = textTransformAbsoluteWithLocalPositionOffset;
 	label.fontSize = effectiveFontSize;
     label.string = effectiveText;
     label.alignmentMode = kCAAlignmentLeft;
-    label.foregroundColor = [UIColor blackColor].CGColor;
+    
+    label.foregroundColor = [SVGHelperUtilities parseFillForElement:self];
 #if TARGET_OS_IPHONE
     label.contentsScale = [[UIScreen mainScreen] scale];
 #endif


### PR DESCRIPTION
text-anchor and fill are simple to support for SVGTextElement, so this patch adds support. The biggest change is in SVGHelperUtilities to split out parsing the fill into a standalone method.

This patch also switches SVGTextElement to use CTLineGetTypographicBounds to get the font's ascent, and uses it as the vertical offset instead of the text bounds' full height. On my system this improves the text positioning to match Safari.
