### PR TITLE
iOS 8 crash on SVG resize.

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -330,7 +330,9 @@ static NSMutableDictionary* globalSVGKImageCache;
     }
 #endif
 	
-//SOMETIMES CRASHES IN APPLE CODE, CAN'T WORK OUT WHY:	[self removeObserver:self forKeyPath:@"DOMTree.viewport"];
+    @try{
+        [self removeObserver:self forKeyPath:@"DomTree.viewport" context:nil];
+    }@catch (NSException * __unused exception) {}
 	
     self.source = nil;
     self.parseErrorsAndWarnings = nil;


### PR DESCRIPTION
After switching to iOS 8, this would crash on any render and resize of all SVG's in my project. This fixes the issue for me.
