### PR TITLE
Fix for external stylesheets to open the stream before reading from it.

### DIFF
--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -358,6 +358,7 @@ SVGKParser* getCurrentlyParsingParser()
     static uint8_t byteBuffer[4096];
     NSInteger bytesRead;
     NSString *result = nil;
+    [src.stream open]; // if we do this, we CANNOT parse from this source again in future
     do
     {
         bytesRead = [src.stream read:byteBuffer maxLength:4096];


### PR DESCRIPTION
Recent changes in SVGKSource moved the call to open the stream from the SVGKSource to code that uses it. Those changes missed the (little-used) support for external stylesheets; this pull request fixes the omission.
