### PR TITLE
Adding the resolutions for the iPhone 6 and iPhone 6+. Fixes #215

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -141,14 +141,17 @@ static float cachedDevicePixelsPerInch;
 	|| [platform hasPrefix:@"iPhone3"])
 		return 163.0f;
 	
-	if( [platform hasPrefix:@"iPhone4"]
-	|| [platform hasPrefix:@"iPhone5"]
-	|| [platform hasPrefix:@"iPhone6"])
-		return 326.0f;
-	
-    if([platform hasPrefix:@"iPhone7"]) //iphone 6 and 6+
-        return 401.0f;
+    if( [platform hasPrefix:@"iPhone4"]
+       || [platform hasPrefix:@"iPhone5"]
+       || [platform hasPrefix:@"iPhone6"]
+       || [platform hasPrefix:@"iPhone7,2"]) {
+        return 326.0f;
+    }
     
+    if ( [platform hasPrefix:@"iPhone7,1"]) {
+        return 401.0f;
+    }
+	
 	if( [platform hasPrefix:@"iPhone"]) // catch-all for higher-end devices not yet existing
 	{
 		NSAssert(FALSE, @"Not supported yet: you are using an iPhone that didn't exist when this code was written, we have no idea what the pixel count per inch is!");


### PR DESCRIPTION
The previous PR, #217, only has the iPhone 6 Plus resolution. This works on the iPhone 6 and iPhone 6 Plus.
