### PR TITLE
Updating the project settings so NSAssert does not get raised

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -1330,6 +1330,7 @@
 				ARCHS = "$(ARCHS_STANDARD)";
 				DSTROOT = /tmp/SVGKit_iOS.dst;
 				DYLIB_CURRENT_VERSION = 1.2.0;
+				ENABLE_NS_ASSERTIONS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "XCodeProjectData/SVGKit-iOS/SVGKit-iOS-Prefix.pch";
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;


### PR DESCRIPTION
Updating the project settings so NSAssert does not get raised on production builds. Thanks @SachinAhujaGit. Fixes #219
