### PR TITLE
Improve stringFromSource to use the NSData+NSInputStream category.

### DIFF
--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -29,6 +29,7 @@
 #import "SVGKSourceURL.h"
 #import "CSSStyleSheet.h"
 #import "StyleSheetList+Mutable.h"
+#import "NSData+NSInputStream.h"
 
 @interface SVGKParser()
 @property(nonatomic,retain, readwrite) SVGKSource* source;
@@ -355,20 +356,9 @@ SVGKParser* getCurrentlyParsingParser()
 
 - (NSString *)stringFromSource:(SVGKSource *) src
 {
-    static uint8_t byteBuffer[4096];
-    NSInteger bytesRead;
-    NSString *result = nil;
     [src.stream open]; // if we do this, we CANNOT parse from this source again in future
-    do
-    {
-        bytesRead = [src.stream read:byteBuffer maxLength:4096];
-        NSString *read = [[[NSString alloc] initWithBytes:byteBuffer length:bytesRead encoding:NSUTF8StringEncoding] autorelease];
-        if( result )
-            result = [result stringByAppendingString:read];
-        else
-            result = read;
-    } while (bytesRead > 0);
-    return result;
+    NSData *data = [NSData dataWithContentsOfStream:src.stream initialCapacity:4096 error:nil];
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 }
 
 - (void)handleProcessingInstruction:(NSString *)target withData:(NSString *) data


### PR DESCRIPTION
When I added NSData+NSInputStream Adam mentioned that he thought he'd seen similar code somewhere else. I couldn't find it at the time, but of course it was something that I'd done. This pull request fixes the other code (`stringFromSource:` in SVGKParser) to use NSData+NSInputStream. Besides being DRY the NSData+NSInputStream code is safer; the old code in `stringFromSource` had the possibility of generating invalid strings if reading the source data happened to split a multi-byte character since it used string appending.
