### PR TITLE
Add test cases via XCTest

### DIFF
--- a/SVGKit-iOS Tests/Info.plist
+++ b/SVGKit-iOS Tests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.MaddTheSane.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/SVGKit-iOS Tests/SVGKit_iOS-RetainTests.m
+++ b/SVGKit-iOS Tests/SVGKit_iOS-RetainTests.m
@@ -46,14 +46,12 @@
 
 - (void)testReplacing {
 	@try {
-		SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"CurvedDiamond" ofType:@"svg"]];
+		SVGKImage *image = [[SVGKImage alloc] initWithContentsOfFile:[self.pathsToSVGs pathForResource:@"CurvedDiamond" ofType:@"svg"]];
 
 		// Release the image
 		[image release];
 
 		image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Lion" ofType:@"svg"]];
-		// Release the image
-		[image release];
 
 		XCTAssertTrue(YES);
 	}
@@ -63,14 +61,16 @@
 }
 
 - (void)testSameFileTwice {
-	@autoreleasepool {
-		SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
-		SVGKImage *image2 = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
-
-		// Release the images
-		[image release];
-		[image2 release];
-	}
+    XCTAssertNoThrow(^{
+        @autoreleasepool {
+            SVGKImage *image = [[SVGKImage alloc] initWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
+            SVGKImage *image2 = [[SVGKImage alloc] initWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
+            
+            // Release the images
+            [image release];
+            [image2 release];
+        }
+    });
 }
 
 @end

--- a/SVGKit-iOS Tests/SVGKit_iOS-RetainTests.m
+++ b/SVGKit-iOS Tests/SVGKit_iOS-RetainTests.m
@@ -10,15 +10,16 @@
 #import <XCTest/XCTest.h>
 #import "SVGKit.h"
 
-#if ! __has_feature(objc_arc)
-#error This test file must be compiled with ARC.
+#if __has_feature(objc_arc)
+#error This test file must not be compiled with ARC.
 #endif
 
-@interface SVGKit_iOS_ARCRetainTests : XCTestCase
-@property (strong) NSBundle *pathsToSVGs;
+
+@interface SVGKit_iOS_RetainTests : XCTestCase
+@property (retain) NSBundle *pathsToSVGs;
 @end
 
-@implementation SVGKit_iOS_ARCRetainTests
+@implementation SVGKit_iOS_RetainTests
 
 - (void)setUp {
     [super setUp];
@@ -27,6 +28,7 @@
 }
 
 - (void)tearDown {
+	self.pathsToSVGs = nil;
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
@@ -35,9 +37,9 @@
 	XCTAssertNoThrow(^{
 		@autoreleasepool {
 			SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Note" ofType:@"svg"]];
-			// Yes, this is ARC, yes we do this to quiet a warning
-			[image class];
-			image = nil;
+
+			// Release the image
+			[image release];
 		}
 	});
 }
@@ -46,10 +48,13 @@
 	@try {
 		SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"CurvedDiamond" ofType:@"svg"]];
 
-		// Yes, this is ARC, yes we do this to quiet a warning
-		[image class];
+		// Release the image
+		[image release];
 
 		image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Lion" ofType:@"svg"]];
+		// Release the image
+		[image release];
+
 		XCTAssertTrue(YES);
 	}
 	@catch (NSException *exception) {
@@ -62,9 +67,9 @@
 		SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
 		SVGKImage *image2 = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
 
-		// Yes, this is ARC, yes we do this to quiet a warning
-		[image class];
-		[image2 class];
+		// Release the images
+		[image release];
+		[image2 release];
 	}
 }
 

--- a/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
+++ b/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
@@ -58,14 +58,16 @@
 }
 
 - (void)testSameFileTwice {
-	@autoreleasepool {
-		SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
-		SVGKImage *image2 = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
-
-		// Yes, this is ARC, yes we do this to quiet a warning
-		[image class];
-		[image2 class];
-	}
+    XCTAssertNoThrow(^{
+        @autoreleasepool {
+            SVGKImage *image = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
+            SVGKImage *image2 = [SVGKImage imageWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Monkey" ofType:@"svg"]];
+            
+            // Yes, this is ARC, yes we do this to quiet a warning
+            [image class];
+            [image2 class];
+        }
+    });
 }
 
 @end

--- a/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
+++ b/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
@@ -1,0 +1,40 @@
+//
+//  SVGKit_iOS_Tests.m
+//  SVGKit-iOS Tests
+//
+//  Created by C.W. Betts on 10/13/14.
+//  Copyright (c) 2014 na. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface SVGKit_iOS_Tests : XCTestCase
+
+@end
+
+@implementation SVGKit_iOS_Tests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    XCTAssert(YES, @"Pass");
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -26,6 +26,15 @@
 		036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */; };
 		55452BF619EC68A200B75A30 /* SVGKit_iOS_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */; };
 		55452BF719EC68A200B75A30 /* libSVGKit-iOS.1.2.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639618E16145D0400E58CCA /* libSVGKit-iOS.1.2.0.a */; };
+		55452C0619EC6C9B00B75A30 /* CurvedDiamond.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452BFF19EC6C9B00B75A30 /* CurvedDiamond.svg */; };
+		55452C0719EC6C9B00B75A30 /* g-element-applies-rotation.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0019EC6C9B00B75A30 /* g-element-applies-rotation.svg */; };
+		55452C0819EC6C9B00B75A30 /* ImageAspectRatio.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0119EC6C9B00B75A30 /* ImageAspectRatio.svg */; };
+		55452C0919EC6C9B00B75A30 /* imagetag-layer2-sun.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0219EC6C9B00B75A30 /* imagetag-layer2-sun.svg */; };
+		55452C0A19EC6C9B00B75A30 /* Lion.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0319EC6C9B00B75A30 /* Lion.svg */; };
+		55452C0B19EC6C9B00B75A30 /* Monkey.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0419EC6C9B00B75A30 /* Monkey.svg */; };
+		55452C0C19EC6C9B00B75A30 /* Note.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452C0519EC6C9B00B75A30 /* Note.svg */; };
+		55452C0E19EC6EC600B75A30 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639633F16145DDC00E58CCA /* libxml2.dylib */; };
+		55825B3A19EC7B4700635497 /* SVGKit_iOS-RetainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55825B3919EC7B4700635497 /* SVGKit_iOS-RetainTests.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		661ADBF316CC2FBE006F4BC3 /* SVGTextPositioningElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */; };
 		661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -296,6 +305,14 @@
 		55452BF119EC68A200B75A30 /* SVGKit-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SVGKit-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55452BF419EC68A200B75A30 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVGKit_iOS_Tests.m; sourceTree = "<group>"; };
+		55452BFF19EC6C9B00B75A30 /* CurvedDiamond.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = CurvedDiamond.svg; path = "Demo-Samples/SVG/CurvedDiamond.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0019EC6C9B00B75A30 /* g-element-applies-rotation.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "g-element-applies-rotation.svg"; path = "Demo-Samples/SVG/g-element-applies-rotation.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0119EC6C9B00B75A30 /* ImageAspectRatio.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = ImageAspectRatio.svg; path = "Demo-Samples/SVG/ImageAspectRatio.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0219EC6C9B00B75A30 /* imagetag-layer2-sun.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "imagetag-layer2-sun.svg"; path = "Demo-Samples/SVG/imagetag-layer2-sun.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0319EC6C9B00B75A30 /* Lion.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = Lion.svg; path = "Demo-Samples/SVG/Lion.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0419EC6C9B00B75A30 /* Monkey.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = Monkey.svg; path = "Demo-Samples/SVG/Monkey.svg"; sourceTree = SOURCE_ROOT; };
+		55452C0519EC6C9B00B75A30 /* Note.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = Note.svg; path = "Demo-Samples/SVG/Note.svg"; sourceTree = SOURCE_ROOT; };
+		55825B3919EC7B4700635497 /* SVGKit_iOS-RetainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SVGKit_iOS-RetainTests.m"; sourceTree = "<group>"; };
 		661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextPositioningElement.h; sourceTree = "<group>"; };
 		661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGTextPositioningElement.m; sourceTree = "<group>"; };
 		661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextContentElement.h; sourceTree = "<group>"; };
@@ -532,6 +549,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55452C0E19EC6EC600B75A30 /* libxml2.dylib in Frameworks */,
 				55452BF719EC68A200B75A30 /* libSVGKit-iOS.1.2.0.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -591,17 +609,34 @@
 			isa = PBXGroup;
 			children = (
 				55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */,
+				55825B3919EC7B4700635497 /* SVGKit_iOS-RetainTests.m */,
 				55452BF319EC68A200B75A30 /* Supporting Files */,
 			);
 			path = "SVGKit-iOS Tests";
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		55452BF319EC68A200B75A30 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
 				55452BF419EC68A200B75A30 /* Info.plist */,
+				55452C0D19EC6CA400B75A30 /* Test SVGs */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		55452C0D19EC6CA400B75A30 /* Test SVGs */ = {
+			isa = PBXGroup;
+			children = (
+				55452BFF19EC6C9B00B75A30 /* CurvedDiamond.svg */,
+				55452C0019EC6C9B00B75A30 /* g-element-applies-rotation.svg */,
+				55452C0119EC6C9B00B75A30 /* ImageAspectRatio.svg */,
+				55452C0219EC6C9B00B75A30 /* imagetag-layer2-sun.svg */,
+				55452C0319EC6C9B00B75A30 /* Lion.svg */,
+				55452C0419EC6C9B00B75A30 /* Monkey.svg */,
+				55452C0519EC6C9B00B75A30 /* Note.svg */,
+			);
+			name = "Test SVGs";
 			sourceTree = "<group>";
 		};
 		6636CD77175F542A0072AAEF /* Sources */ = {
@@ -1193,6 +1228,13 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55452C0719EC6C9B00B75A30 /* g-element-applies-rotation.svg in Resources */,
+				55452C0619EC6C9B00B75A30 /* CurvedDiamond.svg in Resources */,
+				55452C0819EC6C9B00B75A30 /* ImageAspectRatio.svg in Resources */,
+				55452C0A19EC6C9B00B75A30 /* Lion.svg in Resources */,
+				55452C0C19EC6C9B00B75A30 /* Note.svg in Resources */,
+				55452C0919EC6C9B00B75A30 /* imagetag-layer2-sun.svg in Resources */,
+				55452C0B19EC6C9B00B75A30 /* Monkey.svg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1220,6 +1262,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55825B3A19EC7B4700635497 /* SVGKit_iOS-RetainTests.m in Sources */,
 				55452BF619EC68A200B75A30 /* SVGKit_iOS_Tests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1376,11 +1419,20 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
+				HEADER_SEARCH_PATHS = (
+					"Source/**",
+					"calayer-exporter",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "SVGKit-iOS Tests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1410,10 +1462,19 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
+				HEADER_SEARCH_PATHS = (
+					"Source/**",
+					"calayer-exporter",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "SVGKit-iOS Tests/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"$(inherited)",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		00E86D7417415AA000F0FA0A /* SVGKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E86D7317415AA000F0FA0A /* SVGKit.m */; };
 		036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */; };
+		55452BF619EC68A200B75A30 /* SVGKit_iOS_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */; };
+		55452BF719EC68A200B75A30 /* libSVGKit-iOS.1.2.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639618E16145D0400E58CCA /* libSVGKit-iOS.1.2.0.a */; };
 		661ADBF216CC2FBE006F4BC3 /* SVGTextPositioningElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		661ADBF316CC2FBE006F4BC3 /* SVGTextPositioningElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */; };
 		661ADBF716CC2FCA006F4BC3 /* SVGTextContentElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -250,6 +252,16 @@
 		BDA133B819AD0E81003C9945 /* TinySVGTextAreaElement.m in Sources */ = {isa = PBXBuildFile; fileRef = BDA133B619AD0E81003C9945 /* TinySVGTextAreaElement.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		55452BF819EC68A200B75A30 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6639618516145D0400E58CCA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6639618D16145D0400E58CCA;
+			remoteInfo = "SVGKit-iOS";
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		6639618C16145D0400E58CCA /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -281,6 +293,9 @@
 		00E86D7317415AA000F0FA0A /* SVGKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGKit.m; sourceTree = "<group>"; };
 		036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+SVGKExtensions.h"; sourceTree = "<group>"; };
 		036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+SVGKExtensions.m"; sourceTree = "<group>"; };
+		55452BF119EC68A200B75A30 /* SVGKit-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SVGKit-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		55452BF419EC68A200B75A30 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVGKit_iOS_Tests.m; sourceTree = "<group>"; };
 		661ADBF016CC2FBE006F4BC3 /* SVGTextPositioningElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextPositioningElement.h; sourceTree = "<group>"; };
 		661ADBF116CC2FBE006F4BC3 /* SVGTextPositioningElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGTextPositioningElement.m; sourceTree = "<group>"; };
 		661ADBF516CC2FCA006F4BC3 /* SVGTextContentElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGTextContentElement.h; sourceTree = "<group>"; };
@@ -513,6 +528,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		55452BEE19EC68A200B75A30 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55452BF719EC68A200B75A30 /* libSVGKit-iOS.1.2.0.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6639618B16145D0400E58CCA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -564,6 +587,23 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		55452BF219EC68A200B75A30 /* SVGKit-iOS Tests */ = {
+			isa = PBXGroup;
+			children = (
+				55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */,
+				55452BF319EC68A200B75A30 /* Supporting Files */,
+			);
+			path = "SVGKit-iOS Tests";
+			sourceTree = "<group>";
+		};
+		55452BF319EC68A200B75A30 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				55452BF419EC68A200B75A30 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		6636CD77175F542A0072AAEF /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -584,6 +624,7 @@
 			children = (
 				6639633E16145D7700E58CCA /* EXTERNAL REFERENCES */,
 				6649E05E16172CE200AFE92A /* SVGKit-iOS */,
+				55452BF219EC68A200B75A30 /* SVGKit-iOS Tests */,
 				6639619016145D0400E58CCA /* Frameworks */,
 				6639618F16145D0400E58CCA /* Products */,
 			);
@@ -593,6 +634,7 @@
 			isa = PBXGroup;
 			children = (
 				6639618E16145D0400E58CCA /* libSVGKit-iOS.1.2.0.a */,
+				55452BF119EC68A200B75A30 /* SVGKit-iOS Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1077,6 +1119,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		55452BF019EC68A200B75A30 /* SVGKit-iOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 55452BFC19EC68A200B75A30 /* Build configuration list for PBXNativeTarget "SVGKit-iOS Tests" */;
+			buildPhases = (
+				55452BED19EC68A200B75A30 /* Sources */,
+				55452BEE19EC68A200B75A30 /* Frameworks */,
+				55452BEF19EC68A200B75A30 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				55452BF919EC68A200B75A30 /* PBXTargetDependency */,
+			);
+			name = "SVGKit-iOS Tests";
+			productName = "SVGKit-iOS Tests";
+			productReference = 55452BF119EC68A200B75A30 /* SVGKit-iOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		6639618D16145D0400E58CCA /* SVGKit-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6639619C16145D0400E58CCA /* Build configuration list for PBXNativeTarget "SVGKit-iOS" */;
@@ -1104,6 +1164,11 @@
 			attributes = {
 				LastUpgradeCheck = 0440;
 				ORGANIZATIONNAME = na;
+				TargetAttributes = {
+					55452BF019EC68A200B75A30 = {
+						CreatedOnToolsVersion = 6.1;
+					};
+				};
 			};
 			buildConfigurationList = 6639618816145D0400E58CCA /* Build configuration list for PBXProject "SVGKit-iOS" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1118,9 +1183,20 @@
 			projectRoot = "";
 			targets = (
 				6639618D16145D0400E58CCA /* SVGKit-iOS */,
+				55452BF019EC68A200B75A30 /* SVGKit-iOS Tests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		55452BEF19EC68A200B75A30 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		663963481614968A00E58CCA /* ShellScript */ = {
@@ -1140,6 +1216,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		55452BED19EC68A200B75A30 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				55452BF619EC68A200B75A30 /* SVGKit_iOS_Tests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		6639618A16145D0400E58CCA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1255,7 +1339,85 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		55452BF919EC68A200B75A30 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6639618D16145D0400E58CCA /* SVGKit-iOS */;
+			targetProxy = 55452BF819EC68A200B75A30 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		55452BFA19EC68A200B75A30 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "SVGKit-iOS Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		55452BFB19EC68A200B75A30 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "SVGKit-iOS Tests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		6639619A16145D0400E58CCA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1348,6 +1510,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		55452BFC19EC68A200B75A30 /* Build configuration list for PBXNativeTarget "SVGKit-iOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55452BFA19EC68A200B75A30 /* Debug */,
+				55452BFB19EC68A200B75A30 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		6639618816145D0400E58CCA /* Build configuration list for PBXProject "SVGKit-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (


### PR DESCRIPTION
This adds some test cases that test the retain and release of the SVGKImage type. This includes tests using both the old (manual retain count) and new (ARC) memory management routines.
