### PR TITLE
Fix iOS 8 bug with assert fail on infinity CGFloat

### DIFF
--- a/Source/QuartzCore additions/CGPathAdditions.m
+++ b/Source/QuartzCore additions/CGPathAdditions.m
@@ -57,7 +57,7 @@ void applier (void *info, const CGPathElement *element) {
 	CGFloat x = fixInfinity(pathInfo->offX);
 	CGFloat y = fixInfinity(pathInfo->offY);
     
-	const CGPoint *points = fixPointsInfinity(element->points);
+	const CGPoint *points = fixPointsInfinity(element);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:
@@ -102,7 +102,7 @@ void applyPathTranslation (void *info, const CGPathElement *element) {
 	CGFloat x = fixInfinity(pathInfo->offX);
 	CGFloat y = fixInfinity(pathInfo->offY);
 	
-	const CGPoint *points = fixPointsInfinity(element->points);
+	const CGPoint *points = fixPointsInfinity(element);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:

--- a/Source/QuartzCore additions/CGPathAdditions.m
+++ b/Source/QuartzCore additions/CGPathAdditions.m
@@ -15,14 +15,31 @@ typedef struct {
 	CGFloat offY;
 } PathInfo;
 
+CGFloat fixInfinity(CGFloat inputFloat){
+    if(inputFloat>CGFLOAT_MAX) inputFloat=CGFLOAT_MAX;
+    if(inputFloat<(-1)*CGFLOAT_MAX) inputFloat=(-1)*CGFLOAT_MAX;
+    return inputFloat;
+}
+
+CGPoint *fixPointInfinity(CGPoint *inputFloat){
+    int i;
+    for (i = 0; i < sizeof(inputFloat); ++i)
+    {
+        inputFloat[0].x=fixInfinity(inputFloat[0].x);
+        inputFloat[0].y=fixInfinity(inputFloat[0].y);
+
+    }
+    return inputFloat;
+}
+
 void applier (void *info, const CGPathElement *element) {
 	PathInfo *pathInfo = (PathInfo *) info;
 	
 	CGMutablePathRef path = pathInfo->path;
-	CGFloat x = pathInfo->offX;
-	CGFloat y = pathInfo->offY;
-	
-	const CGPoint *points = element->points;
+	CGFloat x = fixInfinity(pathInfo->offX);
+	CGFloat y = fixInfinity(pathInfo->offY);
+    
+	const CGPoint *points = fixPointInfinity(element->points);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:
@@ -51,8 +68,8 @@ CGPathRef CGPathCreateByOffsettingPath (CGPathRef aPath, CGFloat x, CGFloat y) {
 	
 	PathInfo *info = (PathInfo *) malloc(sizeof(PathInfo));
 	info->path = path;
-	info->offX = x;
-	info->offY = y;
+	info->offX = fixInfinity(x);
+	info->offY = fixInfinity(y);
 	
 	CGPathApply(aPath, info, &applier);
 	free(info);
@@ -64,10 +81,10 @@ void applyPathTranslation (void *info, const CGPathElement *element) {
 	PathInfo *pathInfo = (PathInfo *) info;
 	
 	CGMutablePathRef path = pathInfo->path;
-	CGFloat x = pathInfo->offX;
-	CGFloat y = pathInfo->offY;
+	CGFloat x = fixInfinity(pathInfo->offX);
+	CGFloat y = fixInfinity(pathInfo->offY);
 	
-	const CGPoint *points = element->points;
+	const CGPoint *points = fixPointInfinity(element->points);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:
@@ -96,8 +113,8 @@ CGPathRef CGPathCreateByTranslatingPath (CGPathRef aPath, CGFloat x, CGFloat y) 
 	
 	PathInfo *info = (PathInfo *) malloc(sizeof(PathInfo));
 	info->path = path;
-	info->offX = x;
-	info->offY = y;
+	info->offX = fixInfinity(x);
+	info->offY = fixInfinity(y);
 	
 	CGPathApply(aPath, info, &applyPathTranslation);
 	free(info);

--- a/Source/QuartzCore additions/CGPathAdditions.m
+++ b/Source/QuartzCore additions/CGPathAdditions.m
@@ -21,15 +21,33 @@ CGFloat fixInfinity(CGFloat inputFloat){
     return inputFloat;
 }
 
-CGPoint *fixPointInfinity(CGPoint *inputFloat){
-    int i;
-    for (i = 0; i < sizeof(inputFloat); ++i)
+CGPoint *fixPointsInfinity(CGPathElement *element){
+    int i,total;
+    
+    switch (element->type) {
+        case kCGPathElementMoveToPoint:
+            total=1;
+            break;
+        case kCGPathElementAddLineToPoint:
+            total=1;
+            break;
+        case kCGPathElementAddQuadCurveToPoint:
+            total=2;
+            break;
+        case kCGPathElementAddCurveToPoint:
+            total=3;
+            break;
+        default:
+            total=0;
+            break;
+    }
+    for (i = 0; i < total; i++)
     {
-        inputFloat[0].x=fixInfinity(inputFloat[0].x);
-        inputFloat[0].y=fixInfinity(inputFloat[0].y);
+        element->points[i].x=fixInfinity(element->points[i].x);
+        element->points[i].y=fixInfinity(element->points[i].y);
 
     }
-    return inputFloat;
+    return element->points;
 }
 
 void applier (void *info, const CGPathElement *element) {
@@ -39,7 +57,7 @@ void applier (void *info, const CGPathElement *element) {
 	CGFloat x = fixInfinity(pathInfo->offX);
 	CGFloat y = fixInfinity(pathInfo->offY);
     
-	const CGPoint *points = fixPointInfinity(element->points);
+	const CGPoint *points = fixPointsInfinity(element->points);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:
@@ -84,7 +102,7 @@ void applyPathTranslation (void *info, const CGPathElement *element) {
 	CGFloat x = fixInfinity(pathInfo->offX);
 	CGFloat y = fixInfinity(pathInfo->offY);
 	
-	const CGPoint *points = fixPointInfinity(element->points);
+	const CGPoint *points = fixPointsInfinity(element->points);
 	
 	switch (element->type) {
 		case kCGPathElementMoveToPoint:


### PR DESCRIPTION
iOS 8 produce 'inf' CGFloat instead of CGFLOAT_MAX on some CGPath (some bezier paths). But fails when try to assert this CGFloat as a valid float.
"Assertion failed: (CGFloatIsValid(x) && CGFloatIsValid(y)), function void CGPathMoveToPoint(CGMutablePathRef, const CGAffineTransform *, CGFloat, CGFloat), file Paths/CGPath.cc, line 254."

Final iOS 8.1 SDK and XCode 6.1 released but this bug remains. So there is a need for workaround.
This fix replace inf with CGFLOAT_MAX and -inf to -CGFLOAT_MAX in the returned coordinates by quartz
