### PR TITLE
Change Node to make firstChild, lastChild, previousSibling and nextSibling be calculated properties

### DIFF
--- a/Source/DOM classes/Core DOM/Node+Mutable.h
+++ b/Source/DOM classes/Core DOM/Node+Mutable.h
@@ -10,10 +10,6 @@
 @property(nonatomic,readwrite) DOMNodeType nodeType;
 @property(nonatomic,assign,readwrite) Node* parentNode;
 @property(nonatomic,retain,readwrite) NodeList* childNodes;
-@property(nonatomic,assign,readwrite) Node* firstChild;
-@property(nonatomic,assign,readwrite) Node* lastChild;
-@property(nonatomic,assign,readwrite) Node* previousSibling;
-@property(nonatomic,assign,readwrite) Node* nextSibling;
 @property(nonatomic,retain,readwrite) NamedNodeMap* attributes;
 
 @property(nonatomic,assign,readwrite) Document* ownerDocument;

--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -187,6 +187,52 @@
 
 #pragma mark - Official DOM method implementations
 
+-(Node *)firstChild
+{
+    if( [self.childNodes length] < 1 )
+        return nil;
+    else
+        return [self.childNodes item:0];
+}
+
+-(Node *)lastChild
+{
+    if( [self.childNodes length] < 1 )
+        return nil;
+    else
+        return [self.childNodes item: [self.childNodes length] - 1];
+}
+
+-(Node *)previousSibling
+{
+    if( self.parentNode == nil )
+        return nil;
+    else
+    {
+        NSUInteger indexInParent = [self.parentNode.childNodes.internalArray indexOfObject:self];
+        
+        if( indexInParent < 1 )
+            return nil;
+        else
+            return [self.parentNode.childNodes item:indexInParent-1];
+    }
+}
+
+-(Node *)nextSibling
+{
+    if( self.parentNode == nil )
+        return nil;
+    else
+    {
+        NSUInteger indexInParent = [self.parentNode.childNodes.internalArray indexOfObject:self];
+        
+        if( indexInParent >= [self.parentNode.childNodes length] )
+            return nil;
+        else
+            return [self.parentNode.childNodes item:indexInParent + 1];
+    }
+}
+
 -(Node*) insertBefore:(Node*) newChild refChild:(Node*) refChild
 {
 	if( refChild == nil )


### PR DESCRIPTION
The current implementation of Node never sets the firstChild, lastChild, previousSibling and nextSibling properties, meaning that they don't work. The DOM spec says that these properties are readonly. This makes them good candidates for calculated properties, based on the childNodes list. SVGKit already has a class, SVGElementInstance, that implements these as calculated properties. This pull request copies the code for these properties from SVGElementInstance.m into Node.m, and changes Node+Mutable.h to not make them readwrite.

The motivation for this change is the scenario where the SVG DOM is queried and modified, for example for apps that support minor edits of the SVG.

The other option for changing firstChild, lastChild, previousSibling and nextSibling would be to keep them as real properties and to make methods like insertBefore, replaceChild, removeChild and appendChild update them as appropriate. However I believe that this approach would be harder to maintain, and easier for them to get into an inconsistent state.
