### PR TITLE
Fix issue with editing/reloading XML

### DIFF
--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -575,7 +575,7 @@
 		case DOMNodeType_DOCUMENT_NODE:
 		case DOMNodeType_ELEMENT_NODE:
 		{
-			[outputString appendString:@">\n"];
+			[outputString appendString:@">"];
 		}break;
 			
 		case DOMNodeType_DOCUMENT_TYPE_NODE:
@@ -638,7 +638,7 @@
 		case DOMNodeType_DOCUMENT_NODE:
 		case DOMNodeType_ELEMENT_NODE:
 		{
-			[outputString appendFormat:@"</%@>\n", self.nodeName];
+			[outputString appendFormat:@"</%@>", self.nodeName];
 		}break;
 			
 		case DOMNodeType_DOCUMENT_TYPE_NODE:

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -658,7 +658,7 @@ static NSMutableDictionary* globalSVGKImageCache;
 	 
 	 (parent may have to change its size to fit children)
 	 */
-	NSUInteger childCount = 0;
+	NSUInteger sublayerCount = 0;
 	for (SVGElement *child in childNodes )
 	{
 		if ([child conformsToProtocol:@protocol(ConverterSVGToCALayer)]) {
@@ -669,12 +669,17 @@ static NSMutableDictionary* globalSVGKImageCache;
 				continue;
 			}
 			
-			childCount++;
+			sublayerCount++;
 			[layer addSublayer:sublayer];
 		}
 	}
 	
-	if ( childCount < 1 ) {
+	/**
+	 If none of the child nodes return a CALayer, we're safe to early-out here (and in fact we need to because
+	 calling setNeedsDisplay on an image layer hides the image). We can't just check childNodes.count because
+	 there may be some nodes like whitespace nodes for which we don't create layers.
+	 */
+	if ( sublayerCount < 1 ) {
 		return layer;
 	}
 	

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -653,15 +653,12 @@ static NSMutableDictionary* globalSVGKImageCache;
         [clipLayer release]; // because it was created with a +1 retain count
     }
 	
-	if ( childNodes.length < 1 ) {
-		return layer;
-	}
-	
 	/**
 	 Generate child nodes and then re-layout
 	 
 	 (parent may have to change its size to fit children)
 	 */
+	NSUInteger childCount = 0;
 	for (SVGElement *child in childNodes )
 	{
 		if ([child conformsToProtocol:@protocol(ConverterSVGToCALayer)]) {
@@ -670,10 +667,15 @@ static NSMutableDictionary* globalSVGKImageCache;
 			
 			if (!sublayer) {
 				continue;
-            }
+			}
 			
+			childCount++;
 			[layer addSublayer:sublayer];
 		}
+	}
+	
+	if ( childCount < 1 ) {
+		return layer;
 	}
 	
 	/** ...relayout */


### PR DESCRIPTION
When XML is saved and reloaded, images fail to display. This patch fixes the issue twice.

The issue was caused by the fact that SVGKImage.newLayerWithElement calls `[layer setNeedsDisplay]` if the layer has any child nodes. This apparently keeps layers with image content from displaying the image (thanks Apple). Normally <image> elements shouldn't have any whitespace, but Node.appendXMLToString adds newlines after every starting element, and always creates separate ending element tags. This is enough to create a text child within the <image> element.

There are two fixes:
1) Don't append newlines when outputting XML. Existing whitespace in Text children is already preserved and is sufficient.
2) Only count child nodes that create layers when deciding whether to return early in SVGKImage.newLayerWithElement; this prevents whitespace nodes from affecting the behavior.
