### PR TITLE
Infer width and height from viewBox

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.h
+++ b/Source/DOM classes/SVG-DOM/SVGLength.h
@@ -57,6 +57,7 @@ typedef enum SVG_LENGTH_TYPE
 
 +(SVGLength*) svgLengthZero;
 +(SVGLength*) svgLengthFromNSString:(NSString*) s;
++(SVGLength*) svgLengthFromNumber:(float) f;
 
 /** returns this SVGLength as if it had been converted to pixels, using [self convertToSpecifiedUnits:SVG_LENGTHTYPE_PX]
  */

--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -112,6 +112,18 @@ static float cachedDevicePixelsPerInch;
 	return result;
 }
 
++(SVGLength*) svgLengthFromNumber:(float) f
+{
+    CSSPrimitiveValue* pv = [[[CSSPrimitiveValue alloc] init] autorelease];
+
+    pv.pixelsPerInch = cachedDevicePixelsPerInch;
+    [pv setFloatValue:CSS_NUMBER floatValue:f];
+
+    SVGLength* result = [[[SVGLength alloc] initWithCSSPrimitiveValue:pv] autorelease];
+
+    return result;
+}
+
 -(float) pixelsValue
 {
 	return [self.internalCSSPrimitiveValue getFloatValue:CSS_PX];

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -139,37 +139,50 @@
 		self.height = nil; // i.e. undefined
 	else
 		self.height = [SVGLength svgLengthFromNSString:[self getAttribute:@"height"]];
-	
-	/* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
-	if( self.width != nil && self.height != nil )
-		self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
-	else
-		self.requestedViewport = SVGRectUninitialized();
-	
-	
-	/**
-	 NB: this is VERY CONFUSING due to badly written SVG Spec, but: the viewport MUST NOT be set by the parser,
-	 it MUST ONLY be set by the "renderer" -- and the renderer MAY have decided to use a different viewport from
-	 the one that the SVG file *implies* (e.g. if the user scales the SVG, the viewport WILL BE DIFFERENT,
-	 by definition!
-	 
-	 ...However: the renderer will ALWAYS start with the default viewport values (that are calcualted by the parsing process)
-	 and it makes it much cleaner and safer to implement if we have the PARSER set the viewport initially
-	 
-	 (and the renderer will IMMEDIATELY overwrite them once the parsing is finished IFF IT NEEDS TO)
-	 */
-	self.viewport = self.requestedViewport; // renderer can/will change the .viewport, but .requestedViewport can only be set by the PARSER
-	
+
+
 	if( [[self getAttribute:@"viewBox"] length] > 0 )
 	{
 		NSArray* boxElements = [[self getAttribute:@"viewBox"] componentsSeparatedByString:@" "];
 		
 		_viewBox = SVGRectMake([[boxElements objectAtIndex:0] floatValue], [[boxElements objectAtIndex:1] floatValue], [[boxElements objectAtIndex:2] floatValue], [[boxElements objectAtIndex:3] floatValue]);
-	}
+
+        /**
+         Infer width and height from viewBox if not specified
+         */
+
+        if (self.width == nil)
+            self.width = [SVGLength svgLengthFromNumber:_viewBox.width];
+
+        if (self.height == nil)
+            self.height = [SVGLength svgLengthFromNumber:_viewBox.height];
+    }
 	else
 	{
 		self.viewBox = SVGRectUninitialized(); // VERY IMPORTANT: we MUST make it clear this was never initialized, instead of saying its 0,0,0,0 !		
 	}
+
+
+    /* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
+    if( self.width != nil && self.height != nil )
+        self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
+    else
+        self.requestedViewport = SVGRectUninitialized();
+
+
+    /**
+     NB: this is VERY CONFUSING due to badly written SVG Spec, but: the viewport MUST NOT be set by the parser,
+     it MUST ONLY be set by the "renderer" -- and the renderer MAY have decided to use a different viewport from
+     the one that the SVG file *implies* (e.g. if the user scales the SVG, the viewport WILL BE DIFFERENT,
+     by definition!
+
+     ...However: the renderer will ALWAYS start with the default viewport values (that are calcualted by the parsing process)
+     and it makes it much cleaner and safer to implement if we have the PARSER set the viewport initially
+
+     (and the renderer will IMMEDIATELY overwrite them once the parsing is finished IFF IT NEEDS TO)
+     */
+    self.viewport = self.requestedViewport; // renderer can/will change the .viewport, but .requestedViewport can only be set by the PARSER
+
 	
 	self.preserveAspectRatio = [[SVGAnimatedPreserveAspectRatio new] autorelease]; // automatically sets defaults
 	

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -130,7 +130,17 @@
 	NSString* stringWidth = [self getAttribute:@"width"];
 	NSString* stringHeight = [self getAttribute:@"height"];
 	
-	if( stringWidth == nil || stringWidth.length < 1 )
+    /**
+     Ignore percetage width and heights which are only used when rendering in HTML
+     */
+
+    if ([stringWidth containsString:@"%"])
+        stringWidth = nil;
+
+    if ([stringHeight containsString:@"%"])
+        stringHeight = nil;
+
+    if( stringWidth == nil || stringWidth.length < 1 )
 		self.width = nil; // i.e. undefined
 	else
 		self.width = [SVGLength svgLengthFromNSString:[self getAttribute:@"width"]];

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -232,19 +232,6 @@
 			DDLogWarn(@"Found unexpected preserve-aspect-ratio command inside element's 'preserveAspectRatio' attribute. Command = '%@'", aspectRatioCommand );
 		}
 	}
-
-	if( stringWidth == nil || stringWidth.length < 1 )
-		self.width = nil; // i.e. undefined
-	else
-		self.width = [SVGLength svgLengthFromNSString:[self getAttribute:@"width"]];
-	    //osx logging
-#if TARGET_OS_IPHONE        
-        DDLogVerbose(@"[%@] DEBUG INFO: set document viewBox = %@", [self class], NSStringFromCGRect( CGRectFromSVGRect(self.viewBox)));
-#else
-        //mac logging
-     DDLogVerbose(@"[%@] DEBUG INFO: set document viewBox = %@", [self class], NSStringFromRect(self.viewBox));
-#endif   
-	
 }
 
 - (SVGElement *)findFirstElementOfClass:(Class)classParameter {


### PR DESCRIPTION
Some SVG editors and exporters do not include the `<svg>` "width" and "height" attributes.
e.g.

``` xml
<svg version="1.1"
         xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
         x="0px"
         y="0px"
     viewBox="0 0 104 144">
...
```

SVGKit currently will not render these files. We found that Adobe Illustrator exports files like this if you check the "Responsive" option when exporting.

Additionally, some editors and exporters set percentages as their "width" and "height" values to indicate a relative size at which to display the image to a browser. e.g.

``` xml
<svg version="1.1"
         xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
         x="0px"
         y="0px"
         width="100%"
         height="100%"
     viewBox="0 0 104 144">
...
```

SVGKit currently crashes when rendering these files. We've found that Inskscape saves files like this when saving as "SVG Plain".

This change ensures that:
- Percentage `width`s and `height`s are ignored
- If no `width` and `height` attributes are present, we simply grab the values from the `viewBox` attribute.
