### PR TITLE
iPad Air 2 Compatibility

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -177,7 +177,8 @@ static float cachedDevicePixelsPerInch;
 	|| [platform hasPrefix:@"iPad2"])
 		return 132.0f;
 	if( [platform hasPrefix:@"iPad3"]
-	|| [platform hasPrefix:@"iPad4"])
+	|| [platform hasPrefix:@"iPad4"]
+    || [platform hasPrefix:@"iPad5"])
 		return 264.0f;
 	if( [platform hasPrefix:@"iPad"]) // catch-all for higher-end devices not yet existing
 	{


### PR DESCRIPTION
iPad Air 2 has same PPI as the previous model.
