### PR TITLE
Make changes to rootOfCurrentDocumentFragment and viewportElement propagate to children.

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGElement.m
@@ -40,8 +40,8 @@
 
 @synthesize identifier = _identifier;
 @synthesize xmlbase;
-@synthesize rootOfCurrentDocumentFragment;
-@synthesize viewportElement;
+@synthesize rootOfCurrentDocumentFragment = _rootOfCurrentDocumentFragment;
+@synthesize viewportElement = _viewportElement;
 @synthesize stringValue = _stringValue;
 
 @synthesize className; /**< CSS class, from SVGStylable interface */
@@ -171,6 +171,20 @@
 			}
 		}
 	}
+}
+
+- (void)setRootOfCurrentDocumentFragment:(SVGSVGElement *)root {
+    _rootOfCurrentDocumentFragment = root;
+    for (Node *child in self.childNodes)
+        if ([child isKindOfClass:SVGElement.class])
+            ((SVGElement *) child).rootOfCurrentDocumentFragment = root;
+}
+
+- (void)setViewportElement:(SVGElement *)viewport {
+    _viewportElement = viewport;
+    for (Node *child in self.childNodes)
+        if ([child isKindOfClass:SVGElement.class])
+            ((SVGElement *) child).viewportElement = viewport;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
If these changes aren't propagated to child nodes then errors can happen after doing DOM editing and then recreating CALayerTree.
