### PR TITLE
Remove synthesizers of child properties.

### DIFF
--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -22,10 +22,6 @@
 @synthesize nodeType;
 @synthesize parentNode;
 @synthesize childNodes;
-@synthesize firstChild;
-@synthesize lastChild;
-@synthesize previousSibling;
-@synthesize nextSibling;
 @synthesize attributes;
 
 // Modified in DOM Level 2:


### PR DESCRIPTION
This makes it so that the child properties that use a function as a getter aren't generated, and thus doing nothing but taking up RAM.
These were changed in pull request #231 to use functions to get the requested nodes, but the synthesizers weren't.
