### PR TITLE
Fixed crash when changing a SVGKLayeredImageView image

### DIFF
--- a/Source/QuartzCore additions/CAShapeLayerWithClipRender.m
+++ b/Source/QuartzCore additions/CAShapeLayerWithClipRender.m
@@ -12,6 +12,8 @@
 @implementation CAShapeLayerWithClipRender
 
 - (void)renderInContext:(CGContextRef)ctx {
+	if (CGRectIsEmpty(self.bounds)) return;
+
     CALayer *mask = nil;
     if( self.mask != nil ) {
         [CALayerWithClipRender maskLayer:self inContext:ctx];

--- a/Source/QuartzCore additions/SVGKLayer.m
+++ b/Source/QuartzCore additions/SVGKLayer.m
@@ -58,6 +58,12 @@
 - (void)dealloc
 {
 	//FIXME: Apple crashes on this line, even though BY DEFINITION Apple should not be crashing: [self removeObserver:self forKeyPath:@"showBorder"];
+	@try {
+		[self removeObserver:self forKeyPath:@"showBorder"];
+	}
+	@catch (NSException *exception) {
+		DDLogError(@"Exception removing showBorder observer");
+	}
 	
 	self.SVGImage = nil;
 	

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -331,6 +331,12 @@ static NSMutableDictionary* globalSVGKImageCache;
 #endif
 	
 //SOMETIMES CRASHES IN APPLE CODE, CAN'T WORK OUT WHY:	[self removeObserver:self forKeyPath:@"DOMTree.viewport"];
+	@try {
+		[self removeObserver:self forKeyPath:@"DOMTree.viewport"];
+	}
+	@catch (NSException *exception) {
+		DDLogError(@"Exception removing DOMTree.viewport observer");
+	}
 	
     self.source = nil;
     self.parseErrorsAndWarnings = nil;


### PR DESCRIPTION
If I changed a SVGKLayeredImageView image property it would crash on _SVGKImage release because the property observers hadn't been removed. This fixes the issue. Maybe a try catch is not the best way of doing this, but it works.
