### PR TITLE
Fixed bug: opacity attribute is ignored when using fill=url()

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -461,7 +461,8 @@
 			SVGGradientLayer *gradientLayer = [svgGradient newGradientLayerForObjectRect:_shapeLayer.frame viewportRect:svgElement.rootOfCurrentDocumentFragment.viewBox];
 			
 			DDLogCWarn(@"DOESNT WORK, APPLE's API APPEARS BROKEN???? - About to mask layer frame (%@) with a mask of frame (%@)", NSStringFromCGRect(gradientLayer.frame), NSStringFromCGRect(_shapeLayer.frame));
-			gradientLayer.mask =_shapeLayer;
+			gradientLayer.opacity = _shapeLayer.opacity;
+            gradientLayer.mask =_shapeLayer;
             gradientLayer.maskPath = pathToPlaceInLayer;
             CGPathRelease(pathToPlaceInLayer);
 			[_shapeLayer release]; // because it was created with a +1 retain count

--- a/Source/QuartzCore additions/SVGGradientLayer.m
+++ b/Source/QuartzCore additions/SVGGradientLayer.m
@@ -62,6 +62,7 @@
             CGFloat radius = floorf(self.endPoint.x * self.bounds.size.width);
             CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, components, locations, num_locations);
             
+            CGContextSetAlpha(ctx, self.opacity);
             CGContextDrawRadialGradient(ctx, gradient, position, 0, position, radius, kCGGradientDrawsAfterEndLocation);
             
             free(locations);


### PR DESCRIPTION
(https://github.com/SVGKit/SVGKit/issues/272)
