### PR TITLE
Not import unnecessary DOM headers to reduce references.

### DIFF
--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -200,7 +200,7 @@
     if( [self.childNodes length] < 1 )
         return nil;
     else
-        return [self.childNodes item: [self.childNodes length] - 1];
+        return [self.childNodes item: (int)[self.childNodes length] - 1];
 }
 
 -(Node *)previousSibling
@@ -209,7 +209,7 @@
         return nil;
     else
     {
-        NSUInteger indexInParent = [self.parentNode.childNodes.internalArray indexOfObject:self];
+        int indexInParent = (int)[self.parentNode.childNodes.internalArray indexOfObject:self];
         
         if( indexInParent < 1 )
             return nil;
@@ -229,7 +229,7 @@
         if( indexInParent >= [self.parentNode.childNodes length] )
             return nil;
         else
-            return [self.parentNode.childNodes item:indexInParent + 1];
+            return [self.parentNode.childNodes item:(int)indexInParent + 1];
     }
 }
 

--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -522,7 +522,8 @@
 {
     element.preserveAspectRatio = [[SVGAnimatedPreserveAspectRatio new] autorelease]; // automatically sets defaults
     
-    NSString* stringPreserveAspectRatio = [element getAttribute:@"preserveAspectRatio"];
+    Element* node = element;
+    NSString* stringPreserveAspectRatio = [node getAttribute:@"preserveAspectRatio"];
     NSArray* aspectRatioCommands = [stringPreserveAspectRatio componentsSeparatedByString:@" "];
     
     for( NSString* aspectRatioCommand in aspectRatioCommands )

--- a/Source/DOM classes/Unported or Partial DOM/SVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGElement.m
@@ -15,8 +15,9 @@
 #import "CSSRuleList+Mutable.h"
 
 #import "SVGGElement.h"
-
+#import "SVGSVGElement.h"
 #import "SVGRect.h"
+#import "NamedNodeMap.h"
 
 #import "SVGTransformable.h"
 

--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.h
@@ -3,6 +3,7 @@
 #import "SVGElement.h"
 #import "SVGTransformable.h"
 #import "SVGFitToViewBox.h"
+#import "ConverterSVGToCALayer.h"
 
 #import "SVGElement_ForParser.h" // to resolve Xcode circular dependencies; in long term, parsing SHOULD NOT HAPPEN inside any class whose name starts "SVG" (because those are reserved classes for the SVG Spec)
 

--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
@@ -7,6 +7,7 @@
 #import "SVGKImage.h"
 #import "SVGKSourceURL.h"
 #import "SVGKSourceNSData.h"
+#import "SVGSVGElement.h"
 
 #if TARGET_OS_IPHONE
 

--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
@@ -106,7 +106,7 @@ CGImageRef SVGImageCGImage(AppleNativeImageRef img)
 	 */
 	AppleNativeImageRef image = [AppleNativeImage imageWithData:imageData];
 	
-    if( image == nil ) // NSData doesn't contain an imageformat Apple supports; might be an SVG instead
+    if( image == nil && imageURL ) // NSData doesn't contain an imageformat Apple supports; might be an SVG instead
     {
         SVGKImage *svg = nil;
         

--- a/Source/Parsers/Parser Extensions/SVGKParserDOM.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDOM.m
@@ -1,6 +1,7 @@
 #import "SVGKParserDOM.h"
-
+#import "SVGKParseResult.h"
 #import "Node+Mutable.h"
+#import "SVGSVGElement.h"
 
 @implementation SVGKParserDOM
 

--- a/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
@@ -3,6 +3,7 @@
 #import "Node.h"
 #import "SVGKSource.h"
 #import "SVGKParseResult.h"
+#import "SVGDocument.h"
 
 #import "SVGDefsElement.h"
 #import "SVGUseElement.h"

--- a/Source/Parsers/Parser Extensions/SVGKParserStyles.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserStyles.m
@@ -10,6 +10,7 @@
 
 #import "CSSStyleSheet.h"
 #import "StyleSheetList+Mutable.h"
+#import "SVGDocument.h"
 
 @implementation SVGKParserStyles
 

--- a/Source/Parsers/SVGKParseResult.h
+++ b/Source/Parsers/SVGKParseResult.h
@@ -4,11 +4,7 @@
 #import <Foundation/Foundation.h>
 
 @class SVGSVGElement, SVGDocument;
-#import "SVGSVGElement.h"
-#import "SVGDocument.h"
-
 @protocol SVGKParserExtension;
-#import "SVGKParserExtension.h"
 
 @interface SVGKParseResult : NSObject
 
@@ -17,6 +13,7 @@
 /** 0.0 = no parsing done yet, 0.x = partially parsed, 1.0 = parse complete (no fatal errors) */
 @property(nonatomic) double parseProgressFractionApproximate;
 
+@property(nonatomic,readonly) BOOL         hasSVGTree;    /*< whether rootOfSVGTree is valid */
 @property(nonatomic,retain) SVGSVGElement* rootOfSVGTree; /*< both are needed, see spec */
 @property(nonatomic,retain) SVGDocument* parsedDocument; /*< both are needed, see spec */
 

--- a/Source/Parsers/SVGKParseResult.m
+++ b/Source/Parsers/SVGKParseResult.m
@@ -2,7 +2,7 @@
 
 @implementation SVGKParseResult
 
-@synthesize libXMLFailed;
+@synthesize libXMLFailed, hasSVGTree;
 @synthesize parsedDocument, rootOfSVGTree, namespacesEncountered;
 @synthesize warnings, errorsRecoverable, errorsFatal;
 
@@ -86,5 +86,10 @@
 	return d;
 }
 #endif
+
+- (BOOL)hasSVGTree
+{
+    return rootOfSVGTree != nil;
+}
 
 @end

--- a/Source/Parsers/SVGKParser.h
+++ b/Source/Parsers/SVGKParser.h
@@ -37,13 +37,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SVGKSource.h"
 #import "SVGKParserExtension.h"
 #import "SVGKParseResult.h"
 
-#import "SVGElement.h"
-
-
+@class Attr;
 
 /*! RECOMMENDED: leave this set to 1 to get warnings about "legal, but poorly written" SVG */
 #define PARSER_WARN_FOR_ANONYMOUS_SVG_G_TAGS 1

--- a/Source/Parsers/SVGKParserExtension.h
+++ b/Source/Parsers/SVGKParserExtension.h
@@ -14,12 +14,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "SVGKSource.h"
-
+@class SVGKSource;
 @class SVGKParseResult;
-#import "SVGKParseResult.h"
-
-#import "Node.h"
+@class Node;
 
 /*! Experimental: allow SVGKit parser-extensions to insert custom data into an SVGKParseResult */
 #define ENABLE_PARSER_EXTENSIONS_CUSTOM_DATA 0

--- a/Source/QuartzCore additions/CGPathAdditions.m
+++ b/Source/QuartzCore additions/CGPathAdditions.m
@@ -21,7 +21,7 @@ CGFloat fixInfinity(CGFloat inputFloat){
     return inputFloat;
 }
 
-CGPoint *fixPointsInfinity(CGPathElement *element){
+CGPoint *fixPointsInfinity(const CGPathElement *element){
     int i,total;
     
     switch (element->type) {

--- a/Source/QuartzCore additions/SVGKLayer.h
+++ b/Source/QuartzCore additions/SVGKLayer.h
@@ -1,6 +1,6 @@
 #import <QuartzCore/QuartzCore.h>
 
-#import "SVGKit.h"
+#import "SVGKImage.h"
 
 /**
  * SVGKLayer: this is the "low level" equivalent of SVGKImageView, and allows you to perform e.g. CoreAnimation on the individual elemetns / layers

--- a/Source/QuartzCore additions/SVGKLayer.m
+++ b/Source/QuartzCore additions/SVGKLayer.m
@@ -6,7 +6,7 @@
 }
 
 @synthesize SVGImage = _SVGImage;
-@synthesize showBorder;
+@synthesize showBorder = _showBorder;
 
 //self.backgroundColor = [UIColor clearColor];
 
@@ -23,11 +23,10 @@
     if (self)
 	{
     	self.borderColor = [UIColor blackColor].CGColor;
-		
-		[self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:NULL];
     }
     return self;
 }
+
 -(void)setSVGImage:(SVGKImage *) newImage
 {
 	if( newImage == _SVGImage )
@@ -55,10 +54,19 @@
 	}
 }
 
+- (void)setShowBorder:(BOOL)value {
+    _showBorder = value;
+    [self removeObserver:self forKeyPath:@"showBorder"];
+    if (value) {
+        [self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:NULL];
+    }
+}
+
 - (void)dealloc
 {
-	//FIXME: Apple crashes on this line, even though BY DEFINITION Apple should not be crashing: [self removeObserver:self forKeyPath:@"showBorder"];
-	
+    if (_showBorder) {
+        [self removeObserver:self forKeyPath:@"showBorder"];
+    }
 	self.SVGImage = nil;
 	
     [super dealloc];

--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -111,6 +111,7 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage);
 + (SVGKImage*) imageWithSource:(SVGKSource *)newSource; // if you have custom source's you want to use
 
 - (id)initWithContentsOfFile:(NSString *)path;
+- (id)initWithData:(NSData *)data;
 
 #pragma mark - UIImage methods cloned and re-implemented as SVG intelligent methods
 

--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -111,7 +111,6 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage);
 + (SVGKImage*) imageWithSource:(SVGKSource *)newSource; // if you have custom source's you want to use
 
 - (id)initWithContentsOfFile:(NSString *)path;
-- (id)initWithData:(NSData *)data;
 
 #pragma mark - UIImage methods cloned and re-implemented as SVG intelligent methods
 

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -7,6 +7,7 @@
 #import "SVGPathElement.h"
 #import "SVGUseElement.h"
 #import "SVGClipPathElement.h"
+#import "SVGDocument.h"
 
 #import "SVGSVGElement_Mutable.h" // so that changing .size can change the SVG's .viewport
 

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -316,6 +316,11 @@ static NSMutableDictionary* globalSVGKImageCache;
 	return [self initWithSource:[SVGKSourceURL sourceFromURL:url]];
 }
 
+- (id)initWithData:(NSData *)data {
+    NSAssert(false, @"Not implemented yet");
+    return nil;
+}
+
 - (void)dealloc
 {
 #if ENABLE_GLOBAL_IMAGE_CACHE_FOR_SVGKIMAGE_IMAGE_NAMED

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -1,4 +1,5 @@
 #import "SVGKFastImageView.h"
+#import "SVGSVGElement.h"
 
 #define TEMPORARY_WARNING_FOR_APPLES_BROKEN_RENDERINCONTEXT_METHOD 1 // ONLY needed as temporary workaround for Apple's renderInContext bug breaking various bits of rendering: Gradients, Scaling, etc
 

--- a/XCodeProjectData/Demo-iOS/DetailViewController.m
+++ b/XCodeProjectData/Demo-iOS/DetailViewController.m
@@ -9,8 +9,6 @@
 
 #import "MasterViewController.h"
 
-#import "NodeList+Mutable.h"
-
 #import "SVGKFastImageView.h"
 #import "SVGKLayeredImageView.h"
 
@@ -487,7 +485,7 @@ CATextLayer *textLayerForLastTappedLayer;
 	}
 	else
 	{
-		if( document.parseErrorsAndWarnings.rootOfSVGTree != nil )
+		if( document.parseErrorsAndWarnings.hasSVGTree )
 		{
 			//NSLog(@"[%@] Freshly loaded document (name = %@) has size = %@", [self class], name, NSStringFromCGSize(document.size) );
 			


### PR DESCRIPTION
Re-submit #268 based on the newest 2.x branch.
