### PR TITLE
Provides basic support for the SVG <switch> element

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		00E86D7417415AA000F0FA0A /* SVGKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E86D7317415AA000F0FA0A /* SVGKit.m */; };
 		036A524C16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		036A524D16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */; };
+		4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FD821EE1AC69F6600E419D3 /* SVGSwitchElement.h */; };
+		4FD821F11AC69F6600E419D3 /* SVGSwitchElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FD821EF1AC69F6600E419D3 /* SVGSwitchElement.m */; };
 		55452BF619EC68A200B75A30 /* SVGKit_iOS_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */; };
 		55452BF719EC68A200B75A30 /* libSVGKit-iOS.1.2.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6639618E16145D0400E58CCA /* libSVGKit-iOS.1.2.0.a */; };
 		55452C0619EC6C9B00B75A30 /* CurvedDiamond.svg in Resources */ = {isa = PBXBuildFile; fileRef = 55452BFF19EC6C9B00B75A30 /* CurvedDiamond.svg */; };
@@ -302,6 +304,8 @@
 		00E86D7317415AA000F0FA0A /* SVGKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGKit.m; sourceTree = "<group>"; };
 		036A524A16E87693008C1140 /* NSCharacterSet+SVGKExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+SVGKExtensions.h"; sourceTree = "<group>"; };
 		036A524B16E87693008C1140 /* NSCharacterSet+SVGKExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+SVGKExtensions.m"; sourceTree = "<group>"; };
+		4FD821EE1AC69F6600E419D3 /* SVGSwitchElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGSwitchElement.h; sourceTree = "<group>"; };
+		4FD821EF1AC69F6600E419D3 /* SVGSwitchElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGSwitchElement.m; sourceTree = "<group>"; };
 		55452BF119EC68A200B75A30 /* SVGKit-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SVGKit-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		55452BF419EC68A200B75A30 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55452BF519EC68A200B75A30 /* SVGKit_iOS_Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVGKit_iOS_Tests.m; sourceTree = "<group>"; };
@@ -899,6 +903,8 @@
 				66E863681688C2770059C9C4 /* BaseClassForAllSVGBasicShapes.m */,
 				66E863691688C2770059C9C4 /* SVGSVGElement.h */,
 				66E8636A1688C2770059C9C4 /* SVGSVGElement.m */,
+				4FD821EE1AC69F6600E419D3 /* SVGSwitchElement.h */,
+				4FD821EF1AC69F6600E419D3 /* SVGSwitchElement.m */,
 				66E8636B1688C2770059C9C4 /* SVGTextElement.h */,
 				66E8636C1688C2770059C9C4 /* SVGTextElement.m */,
 				66E8636D1688C2770059C9C4 /* SVGTitleElement.h */,
@@ -1109,6 +1115,7 @@
 				6668E2081688D3CF00F774A6 /* SVGGElement.h in Headers */,
 				66988DB3168A001400EC93C7 /* CSSStyleDeclaration.h in Headers */,
 				66988DB7168A004D00EC93C7 /* CSSValue.h in Headers */,
+				4FD821F01AC69F6600E419D3 /* SVGSwitchElement.h in Headers */,
 				66988DBB168A027E00EC93C7 /* CSSRule.h in Headers */,
 				668418C018674A0300C61EC2 /* SVGKExporterNSData.h in Headers */,
 				66988DBF168A031200EC93C7 /* CSSStyleSheet.h in Headers */,
@@ -1377,6 +1384,7 @@
 				6636CD83175F542A0072AAEF /* SVGKSourceURL.m in Sources */,
 				6636CD8B175F54680072AAEF /* CALayer+RecursiveClone.m in Sources */,
 				9ED79A25179D87790048AA5B /* SVGGradientLayer.m in Sources */,
+				4FD821F11AC69F6600E419D3 /* SVGSwitchElement.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1578,6 +1586,7 @@
 				55452BFB19EC68A200B75A30 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		6639618816145D0400E58CCA /* Build configuration list for PBXProject "SVGKit-iOS" */ = {
 			isa = XCConfigurationList;

--- a/Source/DOM classes/Unported or Partial DOM/SVGSwitchElement.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSwitchElement.h
@@ -1,0 +1,11 @@
+
+
+#import "SVGElement.h"
+
+#import "ConverterSVGToCALayer.h"
+
+@interface SVGSwitchElement : SVGElement <ConverterSVGToCALayer>
+
+@property (nonatomic, readonly, strong) NodeList * visibleChildNodes;
+
+@end

--- a/Source/DOM classes/Unported or Partial DOM/SVGSwitchElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSwitchElement.m
@@ -1,0 +1,66 @@
+
+#import "SVGSwitchElement.h"
+#import "CALayerWithChildHitTest.h"
+#import "SVGHelperUtilities.h"
+#import "NodeList+Mutable.h"
+
+@implementation SVGSwitchElement
+
+@synthesize visibleChildNodes = _visibleChildNodes;
+
+- (void)dealloc
+{
+    [_visibleChildNodes release];
+    [super dealloc];
+}
+
+- (CALayer *) newLayer
+{
+    CALayer* _layer = [[CALayerWithChildHitTest layer] retain];
+    
+    [SVGHelperUtilities configureCALayer:_layer usingElement:self];
+    
+    return _layer;
+}
+
+- (NodeList *)visibleChildNodes
+{
+    if (_visibleChildNodes)
+        return _visibleChildNodes;
+    
+    _visibleChildNodes = [[NodeList alloc] init];
+    
+    NSString* localLanguage = [[NSLocale preferredLanguages] firstObject];
+    
+    for ( SVGElement<ConverterSVGToCALayer> *child in self.childNodes )
+    {
+        if ([child conformsToProtocol:@protocol(ConverterSVGToCALayer)])
+        {
+            // spec says if there is no attribute at all then pick it
+            if (![child hasAttribute:@"systemLanguage"])
+            {
+                [_visibleChildNodes.internalArray addObject:child];
+                break;
+            }
+            
+            NSString* languages = [child getAttribute:@"systemLanguage"];
+
+            NSArray* languageCodes = [languages componentsSeparatedByCharactersInSet:
+                                      [NSCharacterSet characterSetWithCharactersInString:@", \t\n\r"]];
+
+            if ([languageCodes containsObject:localLanguage])
+            {
+                [_visibleChildNodes.internalArray addObject:child];
+                break;
+            }
+        
+        }
+    }
+    return _visibleChildNodes;
+}
+
+- (void)layoutLayer:(CALayer *)layer
+{
+    
+}
+@end

--- a/Source/Parsers/Parser Extensions/SVGKParserSVG.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserSVG.m
@@ -14,6 +14,7 @@
 #import "SVGPolygonElement.h"
 #import "SVGPolylineElement.h"
 #import "SVGRectElement.h"
+#import "SVGSwitchElement.h"
 #import "SVGTitleElement.h"
 #import "SVGTextElement.h"
 #import "TinySVGTextAreaElement.h"
@@ -42,8 +43,9 @@ static NSDictionary *elementMap;
                           [SVGPolygonElement class], @"polygon",
                           [SVGPolylineElement class], @"polyline",
                           [SVGRectElement class], @"rect",
+                          [SVGSwitchElement class], @"switch",
                           [SVGTitleElement class], @"title",
-                           [SVGTextElement class], @"text",
+                          [SVGTextElement class], @"text",
                           [TinySVGTextAreaElement class], @"textArea",
 						   nil] retain];
 		}

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -7,6 +7,7 @@
 #import "SVGPathElement.h"
 #import "SVGUseElement.h"
 #import "SVGClipPathElement.h"
+#import "SVGSwitchElement.h"
 
 #import "SVGSVGElement_Mutable.h" // so that changing .size can change the SVG's .viewport
 
@@ -620,7 +621,11 @@ static NSMutableDictionary* globalSVGKImageCache;
 		SVGUseElement* useElement = (SVGUseElement*) element;
 		childNodes = useElement.instanceRoot.correspondingElement.childNodes;
     }
-    
+    else
+    if ( [element isKindOfClass:[SVGSwitchElement class]] )
+    {
+        childNodes = [(SVGSwitchElement*) element visibleChildNodes];
+    }
     /**
      Special handling for clip-path; need to create their children
      */


### PR DESCRIPTION
Example usage:

```
<switch>
      <g systemLanguage="en">
        <text x="10" y="20">Something in English</text>
      </g>
      <g systemLanguage="fr, de">
        <text x="10" y="20">French or German</text>
      </g>
      <g>
        <text x="10" y="20">For anyone else</text>
      </g>
    </switch>
```

Does not include full DOM support, nor support for the requiredFeatures or requiredExtensions attributes
