### PR TITLE
Make style attribute parsing more robust.

### DIFF
--- a/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
+++ b/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
@@ -88,7 +88,11 @@
 				{
 					valueAsInches = self.internalValue * 12.0f / 72.0f;
 				}break;
-				
+                case CSS_IN:
+                {
+                    valueAsInches = self.internalValue;
+                }break;
+                    
 				default:
 				{
 					NSAssert( FALSE, @"This line is impossible but Apple's compiler is crap" );

--- a/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
+++ b/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
@@ -88,11 +88,11 @@
 				{
 					valueAsInches = self.internalValue * 12.0f / 72.0f;
 				}break;
-                case CSS_IN:
-                {
-                    valueAsInches = self.internalValue;
-                }break;
-                    
+				case CSS_IN:
+				{
+					valueAsInches = self.internalValue;
+				}break;
+					
 				default:
 				{
 					NSAssert( FALSE, @"This line is impossible but Apple's compiler is crap" );

--- a/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
+++ b/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
@@ -74,7 +74,7 @@
         /* SVG spec specifies some attribute lists might be delimited by white space.
          e.g. stroke-dasharray is 'A list of comma and/or white space separated <length>s'
          http://www.w3.org/TR/SVG/painting.html */
-		if (c == '\n' || c == '\t') {
+		if (isspace(c)) {
 			continue;
 		}
 		


### PR DESCRIPTION
Inline style declarations containing spaces were being ignored. With this change, a style declaration like:

```
... style="fill: orange; stroke : black ; stroke-width: 2"/>

```

is now parsed correctly.
