### PR TITLE
More robust inline style parsing.

### DIFF
--- a/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
+++ b/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
@@ -74,7 +74,7 @@
         /* SVG spec specifies some attribute lists might be delimited by white space.
          e.g. stroke-dasharray is 'A list of comma and/or white space separated <length>s'
          http://www.w3.org/TR/SVG/painting.html */
-		if (c == '\n' || c == '\t') {
+		if (isspace(c)) {
 			continue;
 		}
 		


### PR DESCRIPTION
Inline style declarations containing spaces were being ignored. With this change, a style declaration like:

```
... style="fill: orange; stroke : black ; stroke-width: 2"/>
```

is now parsed correctly.
