### PR TITLE
Convert inches to inches.

### DIFF
--- a/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
+++ b/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
@@ -88,7 +88,11 @@
 				{
 					valueAsInches = self.internalValue * 12.0f / 72.0f;
 				}break;
-				
+				case CSS_IN:
+				{
+					valueAsInches = self.internalValue;
+				}break;
+					
 				default:
 				{
 					NSAssert( FALSE, @"This line is impossible but Apple's compiler is crap" );


### PR DESCRIPTION
Dimensions specified in inches should no longer assert and crash.
