### PR TITLE
Initial support for relative coordinates and lengths

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -353,12 +353,23 @@
 	//DEBUG ONLY: CGRect shapeLayerFrame = _shapeLayer.frame;
 	
 	NSString* actualStroke = [svgElement cascadedValueForStylableProperty:@"stroke"];
+	if (!actualStroke)
+		actualStroke = @"none";
 	NSString* actualStrokeWidth = [svgElement cascadedValueForStylableProperty:@"stroke-width"];
-	if( actualStroke.length > 0
+
+	CGFloat strokeWidth = 1.0;
+	
+	if (actualStrokeWidth)
+	{
+		SVGRect r = ((SVGSVGElement*) svgElement.viewportElement).viewport;
+		
+		strokeWidth = [[SVGLength svgLengthFromNSString:actualStrokeWidth]
+							pixelsValueWithDimension: hypot(r.width, r.height)];
+	}
+	
+	if( strokeWidth > 0
 	   && (! [@"none" isEqualToString:actualStroke]) )
 	{
-		CGFloat strokeWidth = actualStrokeWidth.length > 0 ? [actualStrokeWidth floatValue] : 1.0f;
-		
 		/*
 		 We have to apply any scale-factor part of the affine transform to the stroke itself (this is bizarre and horrible, yes, but that's the spec for you!)
 		 */

--- a/Source/DOM classes/SVG-DOM/SVGLength.h
+++ b/Source/DOM classes/SVG-DOM/SVGLength.h
@@ -61,6 +61,11 @@ typedef enum SVG_LENGTH_TYPE
 /** returns this SVGLength as if it had been converted to pixels, using [self convertToSpecifiedUnits:SVG_LENGTHTYPE_PX]
  */
 -(float) pixelsValue;
+
+/** to calculate relative values pass in the appropriate viewport dimension (width, height, or diagonal measure)
+*/
+-(float) pixelsValueWithDimension:(float)dimension;
+
 /** returns this SVGLength as if it had been converted to a raw number (USE pixelsValue instead, UNLESS you are dealing with something that you expect to be a percentage or
  similar non-pixel value), using [self convertToSpecifiedUnits:SVG_LENGTHTYPE_NUMBER]
  */

--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -117,6 +117,14 @@ static float cachedDevicePixelsPerInch;
 	return [self.internalCSSPrimitiveValue getFloatValue:CSS_PX];
 }
 
+-(float) pixelsValueWithDimension:(float)dimension
+{
+    if (self.internalCSSPrimitiveValue.primitiveType == CSS_PERCENTAGE)
+        return dimension * self.value / 100.0;
+    
+    return [self pixelsValue];
+}
+
 -(float) numberValue
 {
 	return [self.internalCSSPrimitiveValue getFloatValue:CSS_NUMBER];

--- a/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
@@ -91,8 +91,12 @@ void CGPathAddRoundedRect (CGMutablePathRef path, CGRect rect, CGFloat radiusX, 
 	 Create a square OR rounded rectangle as a CGPath
 	 
 	 */
+
+    SVGRect r = parseResult.rootOfSVGTree.viewport;
+
 	CGMutablePathRef path = CGPathCreateMutable();
-	CGRect rect = CGRectMake([_x pixelsValue], [_y pixelsValue], [_width pixelsValue], [_height pixelsValue]);
+    CGRect rect = CGRectMake([_x pixelsValueWithDimension:r.x], [_y pixelsValueWithDimension:r.y],
+                             [_width pixelsValueWithDimension:r.width], [_height pixelsValueWithDimension:r.height]);
 	
 	CGFloat radiusXPixels = _rx != nil ? [_rx pixelsValue] : 0;
 	CGFloat radiusYPixels = _ry != nil ? [_ry pixelsValue] : 0;


### PR DESCRIPTION
The coordinates and lengths of rects and the "stroke-width" property can now be expressed as relative values. The percentages refer to the dimensions of the enclosing view port. So:

```
  <rect x="10%" y="20%" width="80%" height="30%" stroke-width="2%" stroke="black" fill="green"/>
```

can now be specified. TBD: circles, ellipses and text boxes.
