### PR TITLE
Improve linear gradients

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.h
@@ -33,18 +33,16 @@
     @public
     BOOL radial; /* FIXME: not in SVG Spec */
     
-    @protected
-    NSMutableArray *_stops; /* FIXME: not in SVG Spec */
-    
-    @private
-    NSArray *colors, *locations; /* FIXME: not in SVG Spec */
 }
 
-@property (readonly, retain)NSArray *stops; /* FIXME: not in SVG Spec */
+@property (readonly, retain) NSArray *stops; /* FIXME: not in SVG Spec */
+@property (readonly, retain) NSArray *locations; /* FIXME: not in SVG Spec */
+@property (readonly, retain) NSArray *colors; /* FIXME: not in SVG Spec */
 
 -(void)addStop:(SVGGradientStop *)gradientStop; /* FIXME: not in SVG Spec */
 
 
 -(SVGGradientLayer *)newGradientLayerForObjectRect:(CGRect) objectRect viewportRect:(SVGRect) viewportRect;
 
+- (void)synthesizeProperties; // resolve any xlink:hrefs to other gradients
 @end

--- a/Source/QuartzCore additions/SVGGradientLayer.m
+++ b/Source/QuartzCore additions/SVGGradientLayer.m
@@ -29,8 +29,11 @@
 
 - (void)renderInContext:(CGContextRef)ctx {
     CGContextSaveGState(ctx);
-    CGContextAddPath(ctx, maskPath);
-    CGContextClip(ctx);
+	if (maskPath)
+	{
+    	CGContextAddPath(ctx, maskPath);
+		CGContextClip(ctx);
+	}
     if ([self.type isEqualToString:kExt_CAGradientLayerRadial]) {
         
         size_t num_locations = self.locations.count;


### PR DESCRIPTION
Makes several improvements to linear gradients:

xlink hrefs are now followed for gradients to acquire properties from other gradients
gradient strokes are now supported
better path masking for gradients

To do: improve linear gradients that are using `userSpaceOnUse` coordinates.

![gradients](https://cloud.githubusercontent.com/assets/5883925/6931663/e26df370-d7dd-11e4-959f-2788a0be8d3f.png)
