### PR TITLE
Improvements for userSpaceOnUse linear gradients.

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.h
@@ -42,7 +42,8 @@
 -(void)addStop:(SVGGradientStop *)gradientStop; /* FIXME: not in SVG Spec */
 
 
--(SVGGradientLayer *)newGradientLayerForObjectRect:(CGRect) objectRect viewportRect:(SVGRect) viewportRect;
+-(SVGGradientLayer *)newGradientLayerForObjectRect:(CGRect) objectRect viewportRect:(SVGRect) viewportRect
+										 transform:(CGAffineTransform)transform;
 
 - (void)synthesizeProperties; // resolve any xlink:hrefs to other gradients
 @end


### PR DESCRIPTION
The change here is to pass down the absolute affine transform, so that the userSpaceOnUse linear gradient can be properly transformed. Inkscape seems to favor this type of gradient, and, as shown below, our rendering is now more in line with Inkscape (and other SVG renderers) with these changes.
![gradients2](https://cloud.githubusercontent.com/assets/5883925/6955237/d5f1e202-d8a8-11e4-916a-de0947ec8d55.png)
