### PR TITLE
Ensure that elements referenced by <use> tags have the proper transform.

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -618,15 +618,12 @@ static NSMutableDictionary* globalSVGKImageCache;
 	 */
 	if( [element isKindOfClass:[SVGUseElement class]] )
 	{
-		if ( [element isKindOfClass:[SVGUseElement class]] )
-		{
-			SVGUseElement* useElement = (SVGUseElement*) element;
-			element = (SVGElement <ConverterSVGToCALayer> *)useElement.instanceRoot.correspondingElement;
-			
-			saveParentNode = element.parentNode;
-			element.parentNode = useElement;
-			childNodes = useElement.instanceRoot.correspondingElement.childNodes;
-		}
+		SVGUseElement* useElement = (SVGUseElement*) element;
+		element = (SVGElement <ConverterSVGToCALayer> *)useElement.instanceRoot.correspondingElement;
+		
+		saveParentNode = element.parentNode;
+		element.parentNode = useElement;
+		childNodes = useElement.instanceRoot.correspondingElement.childNodes;
     }
     else
     if ( [element isKindOfClass:[SVGSwitchElement class]] )


### PR DESCRIPTION
Elements referenced by `<use>` elements now conform to the transform at their inserted location. The fix here is to save parent node of the inserted element, then set the parent node to the `<use>` element itself, and finally restore the original parent after rendering.

(This fix is needed for the "arcs02" example from the SVG standard to display correctly.)
