### PR TITLE
More gradient improvements

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -377,9 +377,9 @@
 		/*
 		 We have to apply any scale-factor part of the affine transform to the stroke itself (this is bizarre and horrible, yes, but that's the spec for you!)
 		 */
-		CGSize fakeSize = CGSizeMake( strokeWidth, 0 );
+		CGSize fakeSize = CGSizeMake( strokeWidth, strokeWidth );
 		fakeSize = CGSizeApplyAffineTransform( fakeSize, transformAbsolute );
-		strokeLayer.lineWidth = fakeSize.width;
+		strokeLayer.lineWidth = hypot(fakeSize.width, fakeSize.height)/M_SQRT2;
 		
 		SVGColor strokeColorAsSVGColor = SVGColorFromString([actualStroke UTF8String]); // have to use the intermediate of an SVGColor so that we can over-ride the ALPHA component in next line
 		NSString* actualStrokeOpacity = [svgElement cascadedValueForStylableProperty:@"stroke-opacity"];
@@ -500,7 +500,7 @@
 		maskLayer.strokeColor = nil;
 		gradientLayer.mask = maskLayer;
 		if ( [gradientLayer.type isEqualToString:kExt_CAGradientLayerRadial])
-			gradientLayer.maskPath = pathToPlaceInLayer;
+			gradientLayer.maskPath = fillLayer.path;
 		gradientLayer.frame = fillLayer.frame;
 		fillLayer = (CAShapeLayer* )gradientLayer;
 	}

--- a/Source/DOM classes/Unported or Partial DOM/SVGEllipseElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGEllipseElement.m
@@ -53,7 +53,7 @@
 	if( [[self getAttribute:@"r"] length] > 0 ) { // circle
 		
 		self.ry = self.rx = [[SVGLength svgLengthFromNSString:[self getAttribute:@"r"] ]
-							 pixelsValueWithDimension:hypot(r.width, r.height)];
+							 pixelsValueWithDimension:hypot(r.width, r.height)/M_SQRT2];
 	}
     
     CGMutablePathRef path = CGPathCreateMutable();

--- a/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGradientElement.m
@@ -180,14 +180,6 @@
 		if (!inUserSpace) {
 			gradientLayer.frame = CGRectApplyAffineTransform(objectRect, transformAbsolute);
 			gradientLayer.radialTransform = transformAbsolute;
-			
-			/*
-			CGFloat rotation = atan2(transformAbsolute.b, transformAbsolute.d);
-			CGFloat scaleX = transformAbsolute.a;
-			CGFloat	scaleY = transform.d;
-			
-			if (fabs(rotation)>.01 || scaleX != 1 || scaleY != 1) {
-				*/
 				
 		}
 	} else {

--- a/Source/QuartzCore additions/SVGGradientLayer.h
+++ b/Source/QuartzCore additions/SVGGradientLayer.h
@@ -16,6 +16,9 @@ static NSString * const kExt_CAGradientLayerRadial = @"radialGradient";
 
 @property (nonatomic, readwrite) CGPathRef maskPath;
 @property (nonatomic, readwrite, retain) NSArray *stopIdentifiers;
+@property (nonatomic) CGFloat radius; // radial gradients should have their own properties
+@property (nonatomic) CGPoint centerPoint;
+@property (nonatomic) CGAffineTransform radialTransform;
 
 - (void)setStopColor:(UIColor *)color forIdentifier:(NSString *)identifier;
 

--- a/Source/QuartzCore additions/SVGGradientLayer.m
+++ b/Source/QuartzCore additions/SVGGradientLayer.m
@@ -14,6 +14,15 @@
 @synthesize stopIdentifiers;
 @synthesize transform;
 
+- (id)init
+{
+	if ((self = [super init]))
+	{
+		_radialTransform = CGAffineTransformIdentity;
+	}
+	return self;
+}
+
 - (void)dealloc {
     CGPathRelease(maskPath);
     [stopIdentifiers release];
@@ -28,10 +37,12 @@
 }
 
 - (void)renderInContext:(CGContextRef)ctx {
+	
     CGContextSaveGState(ctx);
-	if (maskPath)
+
+	if (self.maskPath)
 	{
-    	CGContextAddPath(ctx, maskPath);
+		CGContextAddPath(ctx, self.maskPath);
 		CGContextClip(ctx);
 	}
     if ([self.type isEqualToString:kExt_CAGradientLayerRadial]) {
@@ -40,36 +51,27 @@
         
         size_t numbOfComponents = 0;
         CGColorSpaceRef colorSpace = NULL;
-        CGContextConcatCTM(ctx, CGAffineTransformMake(1, 0, 0, 1, self.startPoint.x, self.startPoint.y));
-        CGContextConcatCTM(ctx, self.transform);
-        CGContextConcatCTM(ctx, CGAffineTransformMake(1, 0, 0, 1, -self.startPoint.x, -self.startPoint.y));
-        
+		
         if (self.colors.count) {
             CGColorRef colorRef = (CGColorRef)[self.colors objectAtIndex:0];
             numbOfComponents = CGColorGetNumberOfComponents(colorRef);
             colorSpace = CGColorGetColorSpace(colorRef);
             
             CGFloat *locations = calloc(num_locations, sizeof(CGFloat));
-            CGFloat *components = calloc(num_locations, numbOfComponents * sizeof(CGFloat));
             
             for (int x = 0; x < num_locations; x++) {
                 locations[x] = [[self.locations objectAtIndex:x] floatValue];
-                const CGFloat *comps = CGColorGetComponents((CGColorRef)[self.colors objectAtIndex:x]);
-                for (int y = 0; y < numbOfComponents; y++) {
-                    size_t shift = numbOfComponents * x;
-                    components[shift + y] = comps[y];
-                }
-            }
-            
-            CGPoint position = self.startPoint;
-            CGFloat radius = floorf(self.endPoint.x * self.bounds.size.width);
-            CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, components, locations, num_locations);
-            
-            CGContextSetAlpha(ctx, self.opacity);
-            CGContextDrawRadialGradient(ctx, gradient, position, 0, position, radius, kCGGradientDrawsAfterEndLocation);
+			}
+			
+			CGGradientRef gradient = CGGradientCreateWithColors(colorSpace, (__bridge CFArrayRef) self.colors, locations);
+            CGPoint position = self.centerPoint;
+			
+			CGContextConcatCTM(ctx, self.radialTransform);
+			
+			CGContextSetAlpha(ctx, self.opacity);
+			CGContextDrawRadialGradient(ctx, gradient, position, 0, position, self.radius, kCGGradientDrawsAfterEndLocation);
             
             free(locations);
-            free(components);
             CGGradientRelease(gradient);
         }
     } else {


### PR DESCRIPTION
A few gradient improvements:
- radial gradients with `userSpaceOnUse` are now supported
- linear gradients now rotate when their bounding object rotates
- radial gradients are now clipped to their bounding box
- fixes an issue in which rotating a shape 90° could cause its stroke to disappear
