### PR TITLE
Fix the handling of the <use> element

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGUseElement.m
+++ b/Source/DOM classes/SVG-DOM/SVGUseElement.m
@@ -24,22 +24,7 @@
 
 -(CALayer *)newLayer
 {
-	if( [instanceRoot.correspondingElement respondsToSelector:@selector(newLayer)])
-	{
-		CALayer* initialLayer = [((SVGElement<ConverterSVGToCALayer>*)instanceRoot.correspondingElement) newLayer];
-		
-		if( CGRectIsEmpty( initialLayer.frame ) ) // Avoid Apple's UIKit getting upset by infinitely large/small areas due to floating point inaccuracy
-			return initialLayer;
-		
-		//For Xcode's broken debugger: CGAffineTransform i = initialLayer.affineTransform;
-		//For Xcode's broken debugger: CGAffineTransform mine = self.transform;
-		
-		initialLayer.affineTransform = CGAffineTransformConcat( self.transform, initialLayer.affineTransform );
-		
-		return initialLayer;
-	}
-	else
-		return nil;
+	return [[CALayer layer] retain];
 }
 
 -(void)layoutLayer:(CALayer *)layer

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -8,6 +8,7 @@
 #import "SVGUseElement.h"
 #import "SVGClipPathElement.h"
 #import "SVGSwitchElement.h"
+#import "NodeList+Mutable.h"
 
 #import "SVGSVGElement_Mutable.h" // so that changing .size can change the SVG's .viewport
 
@@ -623,7 +624,10 @@ static NSMutableDictionary* globalSVGKImageCache;
 		
 		saveParentNode = element.parentNode;
 		element.parentNode = useElement;
-		childNodes = useElement.instanceRoot.correspondingElement.childNodes;
+
+		NodeList* nodeList = [[NodeList alloc] init];
+		[nodeList.internalArray addObject:element];
+		childNodes = [nodeList autorelease];
     }
     else
     if ( [element isKindOfClass:[SVGSwitchElement class]] )


### PR DESCRIPTION
Also fixes the compasses' display. (Although one of the images crashes on me for an apparently unrelated reason).

The change here is to treat the `<use>` element as the parent of the referenced element and not as its proxy.
