### PR TITLE
Fix for SVGs which have radius larger than w/h

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRectElement.m
@@ -111,6 +111,12 @@ void CGPathAddRoundedRect (CGMutablePathRef path, CGRect rect, CGFloat radiusX, 
 			radiusYPixels = radiusXPixels;
 		else if( radiusXPixels == 0 && radiusYPixels > 0 ) // if RX unspecified, make it equal to RY
 			radiusXPixels = radiusYPixels;
+        
+        if( radiusXPixels > CGRectGetWidth(rect) / 2 ) // give RX max value of half rect width
+            radiusXPixels = CGRectGetWidth(rect) / 2;
+        
+        if( radiusYPixels > CGRectGetHeight(rect) / 2 ) // give RY max value of half rect height
+            radiusYPixels = CGRectGetHeight(rect) / 2;
 		
 		CGPathAddRoundedRect(path,
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_7_0 


### PR DESCRIPTION
I had an error using SVGKit with an SVG generated by Sketch. I noticed it was because the radius of one of the paths was the same as the width of the element. According to MDN, if the radius is greater than half of the width/height of the element, then is should be interpreted as half of the width/height of the element. This adds that functionality. 

https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx
