### PR TITLE
Correct the default font on text elements.

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -62,9 +62,11 @@
 	CTFontRef font = NULL;
 	if( actualFamily != nil)
 		font = CTFontCreateWithName( (CFStringRef)actualFamily, effectiveFontSize, NULL);
-	if( font == NULL )
-		font = CTFontCreateWithName( (CFStringRef) @"Verdana", effectiveFontSize, NULL); // Spec says to use "whatever default font-family is normal for your system". On iOS, that's Verdana
-	
+	if( font == NULL ) {
+		// Spec says to use "whatever default font-family is normal for your system". Use HelveticaNeue, the default since iOS 7.
+		font = CTFontCreateWithName( (CFStringRef) @"HelveticaNeue", effectiveFontSize, NULL);
+	}
+
 	/** Convert all whitespace to spaces, and trim leading/trailing (SVG doesn't support leading/trailing whitespace, and doesnt support CR LF etc) */
 	
 	NSString* effectiveText = self.textContent; // FIXME: this is a TEMPORARY HACK, UNTIL PROPER PARSING OF <TSPAN> ELEMENTS IS ADDED


### PR DESCRIPTION
As per http://stackoverflow.com/questions/3838336/iphone-system-font, iOS has used Helvetica or HelveticaNeue as their default since at least iOS 7.
