### PR TITLE
Fixing a segfault on image elements with a data URL

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
@@ -92,7 +92,7 @@ CGImageRef SVGImageCGImage(AppleNativeImageRef img)
 	else
 	if( [_href hasPrefix:@"data:"])
 	{
-		_href = [_href stringByReplacingOccurrencesOfString:@"\\s+" 
+		self.href = [_href stringByReplacingOccurrencesOfString:@"\\s+"
 												 withString:@""
 													options:NSRegularExpressionSearch
 													  range:NSMakeRange(0, [_href length]) ];


### PR DESCRIPTION
The segfault occurs when `SVGImageElement` `dealloc` calls `[_href release]` and the `_href` was changed by the `if( [_href hasPrefix:@"data:"])` branch of `newLayer`.

Please let me know if you have any feedback on this :)
