### PR TITLE
Potential overrelease in setter methods

### DIFF
--- a/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
+++ b/Source/DOM classes/Core DOM/CSSPrimitiveValue.m
@@ -224,9 +224,10 @@
 
 -(void)setCssText:(NSString *)newCssText
 {
-	[_cssText release];
+  NSString *oldCSSText = _cssText;
 	_cssText = newCssText;
 	[_cssText retain];
+  [oldCSSText release];
 	
 	/** the css text value has been set, so we need to split the elements up and save them in the internal array */
 	if( _cssText == nil

--- a/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
+++ b/Source/DOM classes/Core DOM/CSSStyleDeclaration.m
@@ -44,9 +44,10 @@
  */
 -(void)setCssText:(NSString *)newCSSText
 {
-	[_cssText release];
-	_cssText = newCSSText;
-	[newCSSText retain];
+  NSString *oldCSSText = _cssText;
+  _cssText = newCSSText;
+  [_cssText retain];
+  [oldCSSText release];
 	
 	/** and now post-process it, *as required by* the CSS/DOM spec... */
 	NSMutableDictionary* processedStyles = [self NSDictionaryFromCSSAttributes:_cssText];

--- a/Source/DOM classes/Core DOM/CSSValueList.m
+++ b/Source/DOM classes/Core DOM/CSSValueList.m
@@ -39,9 +39,10 @@
 
 -(void)setCssText:(NSString *)newCssText
 {
-	[_cssText release];
-	_cssText = newCssText;
-	[_cssText retain];
+  NSString *oldCSSText = _cssText;
+  _cssText = newCssText;
+  [_cssText retain];
+  [oldCSSText release];
 	
 	/** the css text value has been set, so we need to split the elements up and save them in the internal array */
 	SVGKitLogVerbose(@"[%@] received new CSS Text, need to split this and save as CSSValue instances: %@", [self class], _cssText);

--- a/Source/DOM classes/SVG-DOM/SVGDocument.m
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.m
@@ -43,9 +43,10 @@
 
 -(void)setRootElement:(SVGSVGElement *)rootElement
 {
-	[_rootElement release];
+  id oldRootElement = _rootElement;
 	_rootElement = rootElement;
 	[_rootElement retain];
+  [oldRootElement release];
 	
 	/*! SVG spec has two variables with same name, because DOM was written to support
 	 weak programming languages that don't provide full OOP polymorphism.

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -118,8 +118,9 @@
     if (_image) {
         [_image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
     }
-    [_image release];
+    id temp = _image;
     _image = [image retain];
+    [temp release];
     
     /** redraw-observers */
     if( self.disableAutoRedrawAtHighestResolution )


### PR DESCRIPTION
There are several setter methods which  use the following pattern:

```
- (void)setObject:(id)o {
  [_oldObject release];
  _oldObject = o;
 [o retain];
 }
```

if the setter were called twice with the same argument for `o`, then, unless `o` had been retained by some other object in the interim, `o` would have a reference count of zero after the second `release`, and be deallocated. Having little experience with this library, I'm not certain if this would ever happen in practice, but even if it isn't an issue now, it might be prudent to fix it now, in case something changes in the future.
