### PR TITLE
Fix Issue #214

### DIFF
--- a/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
+++ b/SVGKit-iOS Tests/SVGKit_iOS_Tests.m
@@ -47,6 +47,8 @@
 	}
 }
 
+
+
 - (void)testReplacing {
 	@try {
 		@autoreleasepool {
@@ -80,6 +82,24 @@
         }
 		XCTAssertTrue(YES);
     }
+	@catch (NSException *exception) {
+		XCTFail(@"Exception Thrown: %@", exception);
+	}
+}
+
+- (void)testSettingImageMultipleTimes {
+	@try {
+		@autoreleasepool {
+			
+			SVGKFastImageView *imageView = [[SVGKFastImageView alloc] initWithFrame:CGRectMake(0, 0, 50, 50)];
+			imageView.image = nil;
+			imageView.image = [[SVGKImage alloc] initWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Note" ofType:@"svg"]];
+			imageView.image = [[SVGKImage alloc] initWithContentsOfFile:[self.pathsToSVGs pathForResource:@"Note" ofType:@"svg"]];
+			// Yes, this is ARC, yes we do this to quiet a warning
+			XCTAssertNoThrow(imageView = nil);
+		}
+		XCTAssertTrue(YES);
+	}
 	@catch (NSException *exception) {
 		XCTFail(@"Exception Thrown: %@", exception);
 	}

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -152,7 +152,7 @@
   if (!self.didRegisterInternalRedrawObservers) return;
 	[self removeObserver:self  forKeyPath:@"layer" context:internalContextPointerBecauseApplesDemandsIt];
 	[self.layer removeObserver:self forKeyPath:@"transform" context:internalContextPointerBecauseApplesDemandsIt];
-	//[self.image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
+  self.didRegisterInternalRedrawObservers = false;
 }
 
 -(void)setDisableAutoRedrawAtHighestResolution:(BOOL)newValue

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -9,7 +9,7 @@
 @interface SVGKFastImageView ()
 @property(nonatomic,readwrite) NSTimeInterval timeIntervalForLastReRenderOfSVGFromMemory;
 @property (nonatomic, retain) NSDate* startRenderTime, * endRenderTime; /*< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
-@property (nonatomic) BOOL didResigesterObservers, didResigesterInternalRedrawObservers;
+@property (nonatomic) BOOL didRegisterObservers, didRegisterInternalRedrawObservers;
 
 @end
 
@@ -130,8 +130,8 @@
     }
     
     /** other obeservers */
-  if (!self.didResigesterObservers) {
-    self.didResigesterObservers = true;
+  if (!self.didRegisterObservers) {
+    self.didRegisterObservers = true;
     [self addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
     [self addObserver:self forKeyPath:@"tileRatio" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
     [self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
@@ -141,15 +141,15 @@
 
 -(void) addInternalRedrawOnResizeObservers
 {
-  if (self.didResigesterInternalRedrawObservers) return;
-  self.didResigesterInternalRedrawObservers = true;
+  if (self.didRegisterInternalRedrawObservers) return;
+  self.didRegisterInternalRedrawObservers = true;
 	[self addObserver:self forKeyPath:@"layer" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
 	[self.layer addObserver:self forKeyPath:@"transform" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
 }
 
 -(void) removeInternalRedrawOnResizeObservers
 {
-  if (!self.didResigesterInternalRedrawObservers) return;
+  if (!self.didRegisterInternalRedrawObservers) return;
 	[self removeObserver:self  forKeyPath:@"layer" context:internalContextPointerBecauseApplesDemandsIt];
 	[self.layer removeObserver:self forKeyPath:@"transform" context:internalContextPointerBecauseApplesDemandsIt];
 	//[self.image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
@@ -179,7 +179,7 @@
 	else
 		[self removeInternalRedrawOnResizeObservers];
 	
-  if (self.didResigesterObservers) {
+  if (self.didRegisterObservers) {
     [self removeObserver:self forKeyPath:@"image" context:internalContextPointerBecauseApplesDemandsIt];
     [self removeObserver:self forKeyPath:@"tileRatio" context:internalContextPointerBecauseApplesDemandsIt];
     [self removeObserver:self forKeyPath:@"showBorder" context:internalContextPointerBecauseApplesDemandsIt];

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -9,6 +9,8 @@
 @interface SVGKFastImageView ()
 @property(nonatomic,readwrite) NSTimeInterval timeIntervalForLastReRenderOfSVGFromMemory;
 @property (nonatomic, retain) NSDate* startRenderTime, * endRenderTime; /*< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
+@property (nonatomic) BOOL didResigesterObservers, didResigesterInternalRedrawObservers;
+
 @end
 
 @implementation SVGKFastImageView
@@ -115,9 +117,7 @@
         internalContextPointerBecauseApplesDemandsIt = @"Apple wrote the addObserver / KVO notification API wrong in the first place and now requires developers to pass around pointers to fake objects to make up for the API deficicineces. You have to have one of these pointers per object, and they have to be internal and private. They serve no real value.";
     }
 	
-    if (_image) {
-        [_image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
-    }
+    [_image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
     [_image release];
     _image = [image retain];
     
@@ -130,20 +130,26 @@
     }
     
     /** other obeservers */
+  if (!self.didResigesterObservers) {
+    self.didResigesterObservers = true;
     [self addObserver:self forKeyPath:@"image" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
     [self addObserver:self forKeyPath:@"tileRatio" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
     [self addObserver:self forKeyPath:@"showBorder" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
+  }
+
 }
 
 -(void) addInternalRedrawOnResizeObservers
 {
+  if (self.didResigesterInternalRedrawObservers) return;
+  self.didResigesterInternalRedrawObservers = true;
 	[self addObserver:self forKeyPath:@"layer" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
 	[self.layer addObserver:self forKeyPath:@"transform" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
-	//[self.image addObserver:self forKeyPath:@"size" options:NSKeyValueObservingOptionNew context:internalContextPointerBecauseApplesDemandsIt];
 }
 
 -(void) removeInternalRedrawOnResizeObservers
 {
+  if (!self.didResigesterInternalRedrawObservers) return;
 	[self removeObserver:self  forKeyPath:@"layer" context:internalContextPointerBecauseApplesDemandsIt];
 	[self.layer removeObserver:self forKeyPath:@"transform" context:internalContextPointerBecauseApplesDemandsIt];
 	//[self.image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
@@ -173,15 +179,16 @@
 	else
 		[self removeInternalRedrawOnResizeObservers];
 	
-	[self removeObserver:self forKeyPath:@"image" context:internalContextPointerBecauseApplesDemandsIt];
-	[self removeObserver:self forKeyPath:@"tileRatio" context:internalContextPointerBecauseApplesDemandsIt];
-	[self removeObserver:self forKeyPath:@"showBorder" context:internalContextPointerBecauseApplesDemandsIt];
-    
-    if (_image) {
-        [_image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
-    }
-    
-    [_image release];
+  if (self.didResigesterObservers) {
+    [self removeObserver:self forKeyPath:@"image" context:internalContextPointerBecauseApplesDemandsIt];
+    [self removeObserver:self forKeyPath:@"tileRatio" context:internalContextPointerBecauseApplesDemandsIt];
+    [self removeObserver:self forKeyPath:@"showBorder" context:internalContextPointerBecauseApplesDemandsIt];
+  }
+
+
+  
+  [_image removeObserver:self forKeyPath:@"size" context:internalContextPointerBecauseApplesDemandsIt];
+  [_image release];
 	_image = nil;
     self.startRenderTime = nil;
     self.endRenderTime = nil;


### PR DESCRIPTION
Fixes issues #214 for SVGKFastImageView by tracking observers being added and make sure they are only added once and removed if added during dealloc.
### Note

This only fixes SVGKFastImageView it does not touch other classes that might have similar issues.
