### PR TITLE
Fix crash of remove observer twice for normal SVG.

### DIFF
--- a/XCodeProjectData/Demo-iOS/DetailViewController.m
+++ b/XCodeProjectData/Demo-iOS/DetailViewController.m
@@ -663,8 +663,6 @@ CATextLayer *textLayerForLastTappedLayer;
 	if( [keyPath isEqualToString:kTimeIntervalForLastReRenderOfSVGFromMemory ] )
 	{
 		self.labelParseTime.text = [NSString stringWithFormat:@"%@ (parsed: %.2f secs, rendered: %.2f secs)", self.sourceOfCurrentDocument.keyForAppleDictionaries, [self.endParseTime timeIntervalSinceDate:self.startParseTime], self.contentView.timeIntervalForLastReRenderOfSVGFromMemory ];
-		
-		[self.contentView removeObserver:self forKeyPath:kTimeIntervalForLastReRenderOfSVGFromMemory];
 	}
 }
 


### PR DESCRIPTION
Sorry, my mistake. Last PR #402  will cause app crashes for SVG files that do not use layer-animations. The reason is removing observer twice.
