### PR TITLE
Fixed typo in the header file CALayerWithChildHitTest.h

### DIFF
--- a/Source/QuartzCore additions/CALayerWithChildHitTest.h
+++ b/Source/QuartzCore additions/CALayerWithChildHitTest.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
-#import "CALayerWithClipRender.H"
+#import "CALayerWithClipRender.h"
 
 /*!
  * Overrides Apple's CALayer purely to change one method, so that hit-testing


### PR DESCRIPTION
Fixed typo in the header file which makes the project generate a "file not found compilation error" when the HFS+ Case-sensitive File system is set
