### PR TITLE
Add DPI for iPhone SE

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -148,7 +148,8 @@ static float cachedDevicePixelsPerInch;
        || [platform hasPrefix:@"iPhone5"]
        || [platform hasPrefix:@"iPhone6"]
        || [platform hasPrefix:@"iPhone7,2"]
-       || [platform hasPrefix:@"iPhone8,1"]) {
+       || [platform hasPrefix:@"iPhone8,1"]
+       || [platform hasPrefix:@"iPhone8,4"]) {
         return 326.0f;
     }
     


### PR DESCRIPTION
Added the DPI specification for the iPhone SE to SVGLength.m. 

DPI 326 according to: https://en.wikipedia.org/wiki/List_of_iOS_devices.
