### PR TITLE
Additional iPhone 7 and 7 Plus platform strings

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -150,13 +150,15 @@ static float cachedDevicePixelsPerInch;
        || [platform hasPrefix:@"iPhone7,2"]
        || [platform hasPrefix:@"iPhone8,1"]
        || [platform hasPrefix:@"iPhone8,4"]
-       || [platform hasPrefix:@"iPhone9,1"]) {
+       || [platform hasPrefix:@"iPhone9,1"]
+       || [platform hasPrefix:@"iPhone9,3"]) {
         return 326.0f;
     }
     
     if ( [platform hasPrefix:@"iPhone7,1"]
        || [platform hasPrefix:@"iPhone8,2"]
-       || [platform hasPrefix:@"iPhone9,2"]) {
+       || [platform hasPrefix:@"iPhone9,2"]
+       || [platform hasPrefix:@"iPhone9,4") {
         return 401.0f;
     }
 	


### PR DESCRIPTION
Apparently there are two extra platform strings for this year's iPhones.

See https://github.com/fahrulazmi/UIDeviceHardware/pull/13
