### PR TITLE
Changes in the Debug build configuration to improve building static library experience

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -2756,6 +2756,8 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/Source/Core\"",
 				);
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CFLAGS = "-fembed-bitcode";
 				PRODUCT_NAME = "$(TARGET_NAME).${DYLIB_CURRENT_VERSION}";
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
"Build Active Architecture Only" set to NO to make the resulting static lib include both architectures - for Simulator and Device.
"-fembed-bitcode" enables apps built with SVGKit to be submitted to AppStore without deselecting the "include bitcode" checkbox. Having bitcode included is better, because Apple will be able to optimise app footprint.