### PR TITLE
Correct the build error / Use of '@import' when modules are disabled

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -2746,6 +2746,7 @@
 		6639619D16145D0400E58CCA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/SVGKit_iOS.dst;
 				DYLIB_CURRENT_VERSION = 2.0.0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -2766,6 +2767,7 @@
 		6639619E16145D0400E58CCA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/SVGKit_iOS.dst;
 				DYLIB_CURRENT_VERSION = 2.0.0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;


### PR DESCRIPTION
Correct the build error:
 
* SVGKit-iOS-Prefix.pch:7:1: Use of '@import' when modules are disabled

Introduced in PR: https://github.com/SVGKit/SVGKit/pull/511

Ref: Issue #512