### PR TITLE
Remove obsoloete variables in SVGLength

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.h
+++ b/Source/DOM classes/SVG-DOM/SVGLength.h
@@ -45,10 +45,8 @@ typedef enum SVG_LENGTH_TYPE
 
 @interface SVGLength : NSObject
 
-@property(nonatomic,readonly) SVG_LENGTH_TYPE unitType;
-@property(nonatomic) float value;
-@property(nonatomic) float valueInSpecifiedUnits;
-@property(nonatomic,strong) NSString* valueAsString;
+-(SVG_LENGTH_TYPE) unitType;
+-(float) value;
 	
 -(void) newValueSpecifiedUnits:(SVG_LENGTH_TYPE) unitType valueInSpecifiedUnits:(float) valueInSpecifiedUnits;
 -(void) convertToSpecifiedUnits:(SVG_LENGTH_TYPE) unitType;

--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -14,10 +14,6 @@
 
 @implementation SVGLength
 
-@synthesize unitType;
-@synthesize value;
-@synthesize valueInSpecifiedUnits;
-@synthesize valueAsString;
 @synthesize internalCSSPrimitiveValue;
 
 


### PR DESCRIPTION
`SVGLength` has some unused variables which made the impression that, in the debugger, sizes weren't loaded properly.

This fix removes those variables.