### PR TITLE
Fix of drawing curves

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGPathElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGPathElement.m
@@ -124,13 +124,15 @@
                         lastCurve = [SVGKPointsAndPathsParser readSmoothCurvetoCommand:commandScanner
                                                               path:path
                                                         relativeTo:lastCoordinate
-                                                     withPrevCurve:lastCurve];
+                                                     withPrevCurve:lastCurve
+                                                        isRelative:TRUE];
                         lastCoordinate = lastCurve.p;
                     } else if ([@"S" isEqualToString:command]) {
                         lastCurve = [SVGKPointsAndPathsParser readSmoothCurvetoCommand:commandScanner
                                                               path:path
                                                         relativeTo:CGPointZero
-                                                     withPrevCurve:lastCurve];
+                                                     withPrevCurve:lastCurve
+                                                        isRelative:FALSE];
                         lastCoordinate = lastCurve.p;
                     } else if ([@"q" isEqualToString:command]) {
                         lastCurve = [SVGKPointsAndPathsParser readQuadraticCurvetoCommand:commandScanner

--- a/Source/DOM classes/Unported or Partial DOM/SVGPathElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGPathElement.m
@@ -160,13 +160,17 @@
                         lastCoordinate = lastCurve.p;
 					} else if ([@"a" isEqualToString:command]) {
 						lastCurve 	=	[SVGKPointsAndPathsParser readEllipticalArcArguments:commandScanner
-																					 path:path relativeTo:lastCoordinate];
+																					 path:path
+                                                                               relativeTo:lastCoordinate
+                                                                               isRelative:TRUE];
 						
 						lastCoordinate = lastCurve.p;
 						
 					}  else if ([@"A" isEqualToString:command]) {
 						lastCurve 	=	[SVGKPointsAndPathsParser readEllipticalArcArguments:commandScanner
-																					path:path relativeTo:CGPointZero];
+                                                                                     path:path
+                                                                               relativeTo:CGPointZero
+                                                                               isRelative:FALSE];
 						lastCoordinate = lastCurve.p;
 					} else  {
                         SVGKitLogWarn(@"unsupported command %@", command);

--- a/Source/Parsers/SVGKPointsAndPathsParser.h
+++ b/Source/Parsers/SVGKPointsAndPathsParser.h
@@ -77,8 +77,8 @@ BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2);
 + (SVGCurve) readCurvetoCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin isRelative:(BOOL) isRelative;
 + (SVGCurve) readCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin isRelative:(BOOL) isRelative;
 + (SVGCurve) readCurvetoArgument:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin;
-+ (SVGCurve) readSmoothCurvetoCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve;
-+ (SVGCurve) readSmoothCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve;
++ (SVGCurve) readSmoothCurvetoCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve isRelative:(BOOL) isRelative;
++ (SVGCurve) readSmoothCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve isRelative:(BOOL) isRelative;
 + (SVGCurve) readSmoothCurvetoArgument:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve;
 
 + (SVGCurve)  readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin;

--- a/Source/Parsers/SVGKPointsAndPathsParser.h
+++ b/Source/Parsers/SVGKPointsAndPathsParser.h
@@ -81,7 +81,7 @@ BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2);
 + (SVGCurve) readSmoothCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve isRelative:(BOOL) isRelative;
 + (SVGCurve) readSmoothCurvetoArgument:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve;
 
-+ (SVGCurve)  readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin;
++ (SVGCurve)  readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin isRelative:(BOOL) isRelative;
 
 + (CGPoint) readCloseCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin;
 

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -777,10 +777,24 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
 
 + (SVGCurve)readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin
 {
-	NSCharacterSet* cmdFormat = [NSCharacterSet characterSetWithCharactersInString:@"Aa"];
-	
-	[scanner scanCharactersFromSet:cmdFormat intoString:nil];
+    NSCharacterSet* cmdFormat = [NSCharacterSet characterSetWithCharactersInString:@"Aa"];
+    BOOL ok = [scanner scanCharactersFromSet:cmdFormat intoString:nil];
+    
+    NSAssert(ok, @"failed to scan arc to command");
+    if (!ok) return SVGCurveZero;
+    
+    SVGCurve curve = [SVGKPointsAndPathsParser readEllipticalArcArgumentsSequence:scanner path:path relativeTo:origin];
+    
+    if (![scanner isAtEnd]) {
+        curve = [SVGKPointsAndPathsParser readEllipticalArcArgumentsSequence:scanner path:path relativeTo:curve.p];
+    }
+    
+    return curve;
+}
 
++ (SVGCurve)readEllipticalArcArgumentsSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin
+{
+    [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
 	// need to find the center point of the ellipse from the two points and an angle
 	// see http://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes for these calculations
 	

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -600,7 +600,7 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
  smooth-curveto:
  ( "S" | "s" ) wsp* smooth-curveto-argument-sequence
  */
-+ (SVGCurve) readSmoothCurvetoCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve
++ (SVGCurve) readSmoothCurvetoCommand:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve isRelative:(BOOL) isRelative
 {
     NSString* cmd = nil;
     NSCharacterSet* cmdFormat = [NSCharacterSet characterSetWithCharactersInString:@"Ss"];
@@ -611,7 +611,7 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
 	
     [SVGKPointsAndPathsParser readWhitespace:scanner];
     
-    SVGCurve lastCurve = [SVGKPointsAndPathsParser readSmoothCurvetoArgumentSequence:scanner path:path relativeTo:origin withPrevCurve:prevCurve];
+    SVGCurve lastCurve = [SVGKPointsAndPathsParser readSmoothCurvetoArgumentSequence:scanner path:path relativeTo:origin withPrevCurve:prevCurve isRelative:isRelative];
     return lastCurve;
 }
 
@@ -620,12 +620,13 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
  smooth-curveto-argument
  | smooth-curveto-argument comma-wsp? smooth-curveto-argument-sequence
  */
-+ (SVGCurve) readSmoothCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve
++ (SVGCurve) readSmoothCurvetoArgumentSequence:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve isRelative:(BOOL) isRelative
 {
     SVGCurve curve = [SVGKPointsAndPathsParser readSmoothCurvetoArgument:scanner path:path relativeTo:origin withPrevCurve:prevCurve];
     
     if (![scanner isAtEnd]) {
-        curve = [SVGKPointsAndPathsParser readSmoothCurvetoArgumentSequence:scanner path:path relativeTo:curve.p withPrevCurve:curve];
+        CGPoint newOrigin = isRelative ? curve.p : origin;
+        curve = [SVGKPointsAndPathsParser readSmoothCurvetoArgumentSequence:scanner path:path relativeTo:newOrigin withPrevCurve:curve isRelative: isRelative];
     }
     
     return curve;
@@ -638,7 +639,8 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
 + (SVGCurve) readSmoothCurvetoArgument:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin withPrevCurve:(SVGCurve)prevCurve
 {
 	// FIXME: reduce the allocations here; make one SVGCurve and update it, not multiple CGPoint's
-	
+	[SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
+    
     CGPoint p1 = [SVGKPointsAndPathsParser readCoordinatePair:scanner];
     CGPoint coord1 = CGPointMake(p1.x+origin.x, p1.y+origin.y);
     [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
@@ -649,7 +651,11 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
     SVGCurve thisCurve;
     if (SVGCurveEqualToCurve(SVGCurveZero, prevCurve)) {
         // assume control point is coincident with the current point
-        thisCurve = SVGCurveMake(origin.x, origin.y, coord1.x, coord1.y, coord2.x, coord2.y);
+        if (CGPointEqualToPoint(origin, CGPointZero)) {
+            thisCurve = SVGCurveMake(coord1.x, coord1.y, coord1.x, coord1.y, coord2.x, coord2.y);
+        } else {
+            thisCurve = SVGCurveMake(origin.x, origin.y, coord1.x, coord1.y, coord2.x, coord2.y);
+        }
     } else {
         // calculate the mirror of the previous control point
         CGPoint currentPoint = prevCurve.p;

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -649,7 +649,7 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
     SVGCurve thisCurve;
     if (SVGCurveEqualToCurve(SVGCurveZero, prevCurve)) {
         // assume control point is coincident with the current point
-        thisCurve = SVGCurveMake(coord1.x, coord1.y, coord2.x, coord2.y, coord1.x, coord1.y);
+        thisCurve = SVGCurveMake(origin.x, origin.y, coord1.x, coord1.y, coord2.x, coord2.y);
     } else {
         // calculate the mirror of the previous control point
         CGPoint currentPoint = prevCurve.p;

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -781,7 +781,7 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
 	return CGPathGetCurrentPoint(path);
 }
 
-+ (SVGCurve)readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin
++ (SVGCurve)readEllipticalArcArguments:(NSScanner*)scanner path:(CGMutablePathRef)path relativeTo:(CGPoint)origin isRelative:(BOOL) isRelative
 {
     NSCharacterSet* cmdFormat = [NSCharacterSet characterSetWithCharactersInString:@"Aa"];
     BOOL ok = [scanner scanCharactersFromSet:cmdFormat intoString:nil];
@@ -791,8 +791,9 @@ inline BOOL SVGCurveEqualToCurve(SVGCurve curve1, SVGCurve curve2)
     
     SVGCurve curve = [SVGKPointsAndPathsParser readEllipticalArcArgumentsSequence:scanner path:path relativeTo:origin];
     
-    if (![scanner isAtEnd]) {
-        curve = [SVGKPointsAndPathsParser readEllipticalArcArgumentsSequence:scanner path:path relativeTo:curve.p];
+    while (![scanner isAtEnd]) {
+        CGPoint newOrigin = isRelative ? curve.p : origin;
+        curve = [SVGKPointsAndPathsParser readEllipticalArcArgumentsSequence:scanner path:path relativeTo:newOrigin];
     }
     
     return curve;


### PR DESCRIPTION
This PR fix drawing for `S/s` and `A/a` command of `d` attribute in `path` element.
`S/s` command has a weird implementation. Its worked only in some specific cases. So I implemented a right `S/s` command, as it described in [specification](https://www.w3.org/TR/SVG11/paths.html#PathDataCubicBezierCommands). Also add support for multiple parameters for absolute(S) command, like this: `S63 449 102.4 567.2 709 370.3 842.9 220.6`.
For `A/a` command implement support for multiple parameters: `a34,34,0,0,0,8.9-4.4,18.1,18.1,0,0,0-7.7-5.4`.

SVG to test smooth curve specs:
```svg 
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
        <path d="M100 100c-.25 .99-4.96 12.24-10.52 16.53-5.55 4.28-9.77 8.09-10.27 9.08-.5 .1-4.71 3.37-4.71 3.37h8.22s2.96-2.13 7.45-5.61c2.13-1.66 3.84-3.37 5.07-4.73 .1 .37 4.81 1.52 7.1-1.27 2.65-3.24 5.3-11.48 5.59-17.07l-7.93-.3z"/>
</svg>
```
SVG to test arc sequence:
```svg 
<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 115.4 115.6">
    <path d="M50.3,64.9a34,34,0,0,0,8.9-4.4,18.1,18.1,0,0,0-7.7-5.4c-4.5-1.4-12,2-15.4,2.4C36.1,57.5,44.2,67.1,50.3,64.9Z"/>
</svg>
```