### PR TITLE
Fix NSData crash when url or path cannot be opened

### DIFF
--- a/SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch
+++ b/SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch
@@ -4,7 +4,7 @@
 
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>
-@import CocoaLumberjack;
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 #define SVGKIT_LOG_CONTEXT 556
 

--- a/SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch
+++ b/SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch
@@ -4,7 +4,9 @@
 
 #ifdef __OBJC__
 #import <Foundation/Foundation.h>
-#import <CocoaLumberjack/CocoaLumberjack.h>
+@import CocoaLumberjack;
+//Note: Use below import if SVGKit is added via Cocoapods w/o using frameworks.
+//#import <CocoaLumberjack/CocoaLumberjack.h>
 
 #define SVGKIT_LOG_CONTEXT 556
 

--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -50,7 +50,7 @@
 
 @class SVGKImage; // needed for typedef below
 typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVGKParseResult* parseResult );
-typedef void (^SVGKImageLoadContentsDelegate)(BOOL state);
+typedef void (^SVGKImageLoadContentsDelegate)(BOOL state, SVGKImage* loadedImage);
 
 @interface SVGKImage : NSObject // doesn't extend UIImage because Apple made UIImage immutable
 {
@@ -101,7 +101,7 @@ typedef void (^SVGKImageLoadContentsDelegate)(BOOL state);
  */
 +(SVGKParser *) imageAsynchronouslyNamed:(NSString *)name onCompletion:(SVGKImageAsynchronousLoadingDelegate) blockCompleted;
 + (SVGKImage *)imageWithContentsOfFile:(NSString *)path;
-+ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion;
++ (void) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion;
 + (SVGKParser*) imageParserWithContentsOfFileAsynchronously:(NSString *)aPath onCompletion:(SVGKImageAsynchronousLoadingDelegate)blockCompleted;
 + (SVGKImage*) imageWithContentsOfFileAsynchronously:(NSString *)aPath onCompletion:(SVGKImageAsynchronousLoadingDelegate)blockCompleted;
 
@@ -232,7 +232,7 @@ typedef void (^SVGKImageLoadContentsDelegate)(BOOL state);
 #pragma mark ---------end of unsupported items
 
 + (SVGKImage*)imageWithContentsOfURL:(NSURL *)url;
-+ (SVGKImage*)imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion;
++ (void)imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion;
 
 #pragma mark - core methods for interacting with an SVG image usefully (not from UIImage)
 

--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -50,6 +50,7 @@
 
 @class SVGKImage; // needed for typedef below
 typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVGKParseResult* parseResult );
+typedef void (^SVGKImageLoadContentsDelegate)(BOOL state);
 
 @interface SVGKImage : NSObject // doesn't extend UIImage because Apple made UIImage immutable
 {
@@ -100,6 +101,7 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVG
  */
 +(SVGKParser *) imageAsynchronouslyNamed:(NSString *)name onCompletion:(SVGKImageAsynchronousLoadingDelegate) blockCompleted;
 + (SVGKImage *)imageWithContentsOfFile:(NSString *)path;
++ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion;
 + (SVGKParser*) imageParserWithContentsOfFileAsynchronously:(NSString *)aPath onCompletion:(SVGKImageAsynchronousLoadingDelegate)blockCompleted;
 + (SVGKImage*) imageWithContentsOfFileAsynchronously:(NSString *)aPath onCompletion:(SVGKImageAsynchronousLoadingDelegate)blockCompleted;
 
@@ -230,6 +232,7 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVG
 #pragma mark ---------end of unsupported items
 
 + (SVGKImage*)imageWithContentsOfURL:(NSURL *)url;
++ (SVGKImage*)imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion;
 
 #pragma mark - core methods for interacting with an SVG image usefully (not from UIImage)
 

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -199,7 +199,7 @@ static NSMutableDictionary* globalSVGKImageCache;
     }
 }
 
-+ (SVGKImage*) imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion{
++ (void) imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion{
     NSParameterAssert(url != nil);
     BOOL state = YES;
     SVGKImage *img = nil;
@@ -208,13 +208,12 @@ static NSMutableDictionary* globalSVGKImageCache;
             img = [[[self class] alloc] initWithContentsOfURL:url];
         }@catch(NSException *exception){
             state = NO;
-            SVGKitLogWarn(@"%@",exception.description);
+            SVGKitLogVerbose(@"%@",exception.description);
         }@finally{
             if(!completion){
-                completion(state);
+                completion(state,img);
             }
         }
-        return img;
     }
 }
 
@@ -224,7 +223,7 @@ static NSMutableDictionary* globalSVGKImageCache;
     }
 }
 
-+ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion{
++ (void) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion{
     BOOL state = YES;
     @synchronized(self) {
         SVGKImage *img = nil;
@@ -232,13 +231,12 @@ static NSMutableDictionary* globalSVGKImageCache;
             img = [[[self class] alloc] initWithContentsOfFile:aPath];
         }@catch(NSException *exception){
             state = NO;
-            SVGKitLogWarn(@"%@",exception.description);
+            SVGKitLogVerbose(@"%@",exception.description);
         }@finally{
             if(!completion){
-                completion(state);
+                completion(state,img);
             }
         }
-        return img;
     }
 }
 

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -50,6 +50,7 @@
 
 #pragma mark - UIImage methods cloned and re-implemented as SVG intelligent methods
 //NOT DEFINED: what is the scale for a SVGKImage? @property(nonatomic,readwrite) CGFloat            scale __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_4_0);
+typedef void (^LoadImageBlock)(BOOL state);
 
 @end
 
@@ -196,13 +197,50 @@ static NSMutableDictionary* globalSVGKImageCache;
 + (SVGKImage*) imageWithContentsOfURL:(NSURL *)url {
 	NSParameterAssert(url != nil);
 	@synchronized(self) {
-	return [[[self class] alloc] initWithContentsOfURL:url];
+        return [[[self class] alloc] initWithContentsOfURL:url];
     }
 }
 
-+ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath {
++ (SVGKImage*) imageWithContentsOfURL:(NSURL *)url completion:(LoadImageBlock)completion{
+    NSParameterAssert(url != nil);
+    BOOL state = YES;
+    SVGKImage *img = nil;
+    @synchronized(self) {
+        @try{
+            img = [[[self class] alloc] initWithContentsOfURL:url];
+        }@catch(NSException *exception){
+            state = NO;
+            SVGKitLogWarn(@"%@",exception.description);
+        }@finally{
+            if(!completion){
+                completion(state);
+            }
+        }
+        return img;
+    }
+}
+
++ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath  {
     @synchronized(self) {
 	return [[[self class] alloc] initWithContentsOfFile:aPath];
+    }
+}
+
++ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(LoadImageBlock)completion{
+    BOOL state = YES;
+    @synchronized(self) {
+        SVGKImage *img = nil;
+        @try{
+            img = [[[self class] alloc] initWithContentsOfFile:aPath];
+        }@catch(NSException *exception){
+            state = NO;
+            SVGKitLogWarn(@"%@",exception.description);
+        }@finally{
+            if(!completion){
+                completion(state);
+            }
+        }
+        return img;
     }
 }
 

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -50,8 +50,6 @@
 
 #pragma mark - UIImage methods cloned and re-implemented as SVG intelligent methods
 //NOT DEFINED: what is the scale for a SVGKImage? @property(nonatomic,readwrite) CGFloat            scale __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_4_0);
-typedef void (^LoadImageBlock)(BOOL state);
-
 @end
 
 #pragma mark - main class
@@ -201,7 +199,7 @@ static NSMutableDictionary* globalSVGKImageCache;
     }
 }
 
-+ (SVGKImage*) imageWithContentsOfURL:(NSURL *)url completion:(LoadImageBlock)completion{
++ (SVGKImage*) imageWithContentsOfURL:(NSURL *)url completion:(SVGKImageLoadContentsDelegate)completion{
     NSParameterAssert(url != nil);
     BOOL state = YES;
     SVGKImage *img = nil;
@@ -226,7 +224,7 @@ static NSMutableDictionary* globalSVGKImageCache;
     }
 }
 
-+ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(LoadImageBlock)completion{
++ (SVGKImage*) imageWithContentsOfFile:(NSString *)aPath completion:(SVGKImageLoadContentsDelegate)completion{
     BOOL state = YES;
     @synchronized(self) {
         SVGKImage *img = nil;


### PR DESCRIPTION
Added try-catch-finally to avoid fatal exception when loading image contents of a path or url. 

> Error internally in Apple's NSData trying to read from URL 'path to svg file'. Error = Error Domain=NSCocoaErrorDomain Code=256 "The file “svg filename” couldn’t be opened." UserInfo={NSURL=path to svg file}

Use:
`+[SVGKImage imageWithContentsOfURL:completion:]`
`+[SVGKImage imageWithContentsOfFile:completion:]`

