### PR TITLE
Fix trailing comments

### DIFF
--- a/Source/DOM classes/Core DOM/Node.h
+++ b/Source/DOM classes/Core DOM/Node.h
@@ -111,7 +111,7 @@ typedef enum DOMNodeType
 @property(nonatomic,weak,readonly) Node* lastChild;
 @property(nonatomic,weak,readonly) Node* previousSibling;
 @property(nonatomic,weak,readonly) Node* nextSibling;
-@property(nonatomic,strong,readonly) NamedNodeMap* attributes; /*< NB: according to DOM Spec, this is null if the Node is NOT subclassed as an Element */
+@property(nonatomic,strong,readonly) NamedNodeMap* attributes; /**< NB: according to DOM Spec, this is null if the Node is NOT subclassed as an Element */
 
 // Modified in DOM Level 2:
 @property(nonatomic,weak,readonly) Document* ownerDocument;

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.h
@@ -118,7 +118,7 @@
 
 #pragma mark - below here VIOLATES THE STANDARD, but needs to be CAREFULLY merged with spec
 
-- (SVGElement *)findFirstElementOfClass:(Class)classParameter; /*< temporary convenience method until SVGDocument support is complete */
+- (SVGElement *)findFirstElementOfClass:(Class)classParameter; /**< temporary convenience method until SVGDocument support is complete */
 
 #pragma mark - elements REQUIRED to implement the spec but not included in SVG Spec due to bugs in the spec writing!
 

--- a/Source/Parsers/SVGKParseResult.h
+++ b/Source/Parsers/SVGKParseResult.h
@@ -17,8 +17,8 @@
 /** 0.0 = no parsing done yet, 0.x = partially parsed, 1.0 = parse complete (no fatal errors) */
 @property(nonatomic) double parseProgressFractionApproximate;
 
-@property(nonatomic,strong) SVGSVGElement* rootOfSVGTree; /*< both are needed, see spec */
-@property(nonatomic,strong) SVGDocument* parsedDocument; /*< both are needed, see spec */
+@property(nonatomic,strong) SVGSVGElement* rootOfSVGTree; /**< both are needed, see spec */
+@property(nonatomic,strong) SVGDocument* parsedDocument; /**< both are needed, see spec */
 
 @property(nonatomic,strong) NSMutableDictionary* namespacesEncountered; /**< maps "prefix" to "uri" */
 

--- a/Source/QuartzCore additions/SVGKLayer.h
+++ b/Source/QuartzCore additions/SVGKLayer.h
@@ -30,8 +30,8 @@
 @interface SVGKLayer : CALayer
 
 @property(nonatomic,strong) SVGKImage* SVGImage;
-@property(nonatomic) BOOL showBorder; /*< mostly for debugging - adds a coloured 1-pixel border around the image */
+@property(nonatomic) BOOL showBorder; /**< mostly for debugging - adds a coloured 1-pixel border around the image */
 
-@property (nonatomic, strong) NSDate* startRenderTime, * endRenderTime; /*< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
+@property (nonatomic, strong) NSDate* startRenderTime, * endRenderTime; /**< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
 
 @end

--- a/Source/SVGKSource.h
+++ b/Source/SVGKSource.h
@@ -22,7 +22,7 @@
 
 @interface SVGKSource : NSObject <NSCopying>
 
-@property (nonatomic, strong) NSString* svgLanguageVersion; /*< <svg version=""> */
+@property (nonatomic, strong) NSString* svgLanguageVersion; /**< <svg version=""> */
 @property (nonatomic, strong) NSInputStream* stream;
 
 /** If known, the amount of data in bytes contained in this source (e.g. the filesize for a

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -8,7 +8,7 @@
 
 @interface SVGKFastImageView ()
 @property(nonatomic,readwrite) NSTimeInterval timeIntervalForLastReRenderOfSVGFromMemory;
-@property (nonatomic, strong) NSDate* startRenderTime, * endRenderTime; /*< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
+@property (nonatomic, strong) NSDate* startRenderTime, * endRenderTime; /**< for debugging, lets you know how long it took to add/generate the CALayer (may have been cached! Only SVGKImage knows true times) */
 @property (nonatomic) BOOL didRegisterObservers, didRegisterInternalRedrawObservers;
 
 @end

--- a/Source/UIKit additions/SVGKImageView.h
+++ b/Source/UIKit additions/SVGKImageView.h
@@ -18,7 +18,7 @@
 @interface SVGKImageView : UIView
 
 @property(nonatomic,strong) SVGKImage* image;
-@property(nonatomic) BOOL showBorder; /*< mostly for debugging - adds a coloured 1-pixel border around the image */
+@property(nonatomic) BOOL showBorder; /**< mostly for debugging - adds a coloured 1-pixel border around the image */
 
 @property(nonatomic,readonly) NSTimeInterval timeIntervalForLastReRenderOfSVGFromMemory;
 


### PR DESCRIPTION
The format for Doxygen trailing comments was wrong in a few places. These would show up as warnings if SVGKit was built as a dependency for a project that had CLANG_WARN_DOCUMENTATION_COMMENTS=YES enabled. This fixes the comments to use the standard Doxygen trailing comment format.