### PR TITLE
Add Carthage support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@ profile
 *.moved-aside
 build
 
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+Carthage/Checkouts
+Carthage/Build
+
 #VScode
 .vscode

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "CocoaLumberjack/CocoaLumberjack" ~> 3.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "CocoaLumberjack/CocoaLumberjack" "3.4.2"

--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -2691,7 +2691,7 @@
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/3rd-party-frameworks/**";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2728,7 +2728,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/3rd-party-frameworks/**";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
@@ -2749,6 +2749,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/SVGKit_iOS.dst;
 				DYLIB_CURRENT_VERSION = 2.0.0;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/iOS",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch";
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
@@ -2770,6 +2774,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				DSTROOT = /tmp/SVGKit_iOS.dst;
 				DYLIB_CURRENT_VERSION = 2.0.0;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/iOS",
+				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SVGKitLibrary/SVGKit-iOS/SVGKit-iOS-Prefix.pch";
 				HEADER_SEARCH_PATHS = /usr/include/libxml2;
@@ -2801,6 +2809,7 @@
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2843,6 +2852,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/iOS",
 				);
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -2943,6 +2953,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/tvOS",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "SVGKitFrameworks/SVGKitFramework-tvOS/SVGKitFramework-tvOS-Prefix.pch";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -2981,6 +2996,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/3rd-party-frameworks/CocoaLumberjack-2.2.0/tvOS",
+				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREFIX_HEADER = "SVGKitFrameworks/SVGKitFramework-tvOS/SVGKitFramework-tvOS-Prefix.pch";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;


### PR DESCRIPTION
Also Clarity the framework_search_path to allow works for both Carthage && Manually Install user.

The demo project test build success

```bash
➜  SwiftDemo git:(master) ✗ cat Cartfile
github "dreampiggy/SVGKit" "feature_carthage"%

➜  SwiftDemo git:(master) ✗ carthage update --verbose
...
Touch /Users/lizhuoli/Library/Caches/org.carthage.CarthageKit/DerivedData/10.0_10A255/SVGKit/c44613dbfc7860aa2387d639d977461503346dad/Build/Products/Release-iphonesimulator/SVGKit.framework (in target: SVGKitFramework-iOS)
    cd /Users/lizhuoli/Documents/Demo/SwiftDemo/Carthage/Checkouts/SVGKit
    /usr/bin/touch -c /Users/lizhuoli/Library/Caches/org.carthage.CarthageKit/DerivedData/10.0_10A255/SVGKit/c44613dbfc7860aa2387d639d977461503346dad/Build/Products/Release-iphonesimulator/SVGKit.framework

** BUILD SUCCEEDED **
```