### PR TITLE
Add support to CSS color name `transparent`

### DIFF
--- a/Source/Unsorted/SVGUtils.m
+++ b/Source/Unsorted/SVGUtils.m
@@ -8,7 +8,7 @@
 #import "SVGUtils.h"
 
 #define MAX_ACCUM 64
-#define NUM_COLORS 147
+#define NUM_COLORS 148
 
 
 SVGColor ColorValueWithName (const char *name);
@@ -160,7 +160,9 @@ static const char *gColorNames[NUM_COLORS] = {
 	"white",
 	"whitesmoke",
 	"yellow",
-	"yellowgreen"
+	"yellowgreen",
+    // CSS Color
+    "transparent"
 };
 
 static const SVGColor gColorValues[NUM_COLORS] = {
@@ -237,7 +239,9 @@ static const SVGColor gColorValues[NUM_COLORS] = {
 	(SVGColor) { 64,224,208,255 }, (SVGColor) { 238,130,238,255 },
 	(SVGColor) { 245,222,179,255 }, (SVGColor) { 255,255,255,255 },
 	(SVGColor) { 245,245,245,255 }, (SVGColor) { 255,255,0,255 },
-	(SVGColor) { 154,205,50,255 }
+	(SVGColor) { 154,205,50,255 },
+    // CSS Color
+    (SVGColor) { 0, 0, 0, 0}
 };
 
 SVGColor ColorValueWithName (const char *name) {


### PR DESCRIPTION
For `<color>` element, current we support all the color name listed in [SVG 1.1- 147 color names](http://www.december.com/html/spec/colorsvg.html).

However, the `<color>` element, now defined in [CSS spec here](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) supports `transparent` keyword.

The CSS spec for color is huge and supports many complicated color like `hsl()`, `hsla()`. We don't have enough time to support them one by one. But I think thin simple one is easy to implement.

After this fix, we can now correctlly render the [demo SVG from MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fr#Example) for showing `radialGradient-fx` value. The full radialGradient implementation is available soon, this one is much simpler so I create a separate PR.