### PR TITLE
Fix the compile issue for developers who still using Xcode 9 or below without iOS 12 SDK

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
@@ -11,6 +11,11 @@
 #import "SVGUtils.h"
 #import "SVGGradientLayer.h"
 
+// `kCAGradientLayerRadial` this symbol is available since iOS 3.2, but it's not externed to public header until Xcode 10 with iOS 12 SDK, so we define it for user who still use old SDK version.
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_12_0)
+NSString * const kCAGradientLayerRadial = @"radial";
+#endif
+
 @interface SVGRadialGradientElement ()
 
 @property (nonatomic) BOOL hasSynthesizedProperties;

--- a/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
@@ -11,8 +11,8 @@
 #import "SVGUtils.h"
 #import "SVGGradientLayer.h"
 
-// `kCAGradientLayerRadial` this symbol is available since iOS 3.2, but it's not externed to public header until Xcode 10 with iOS 12 SDK, so we define it for user who still use old SDK version.
-#if (__IPHONE_OS_VERSION_MAX_ALLOWED && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_12_0)
+// `kCAGradientLayerRadial` this symbol is available since iOS 3.2/tvOS 9.0/macOS 10.6, but it's not externed to public header until Xcode 10 with iOS 12 SDK, so we define it for user who still use old SDK version.
+#if (__IPHONE_OS_VERSION_MAX_ALLOWED && __IPHONE_OS_VERSION_MAX_ALLOWED < __IPHONE_12_0) || (__TV_OS_VERSION_MAX_ALLOWED && __TV_OS_VERSION_MAX_ALLOWED < __TVOS_12_0) || (__MAC_OS_X_VERSION_MAX_ALLOWED && __MAC_OS_X_VERSION_MAX_ALLOWED < __MAC_10_14)
 NSString * const kCAGradientLayerRadial = @"radial";
 #endif
 


### PR DESCRIPTION
[kCAGradientLayerRadial](https://developer.apple.com/documentation/quartzcore/kcagradientlayerradial?language=objc) this symbol exists in the system from iOS 3.2+. But however, Apple does not expose it until iOS 12 SDK. So we have to define it with the real value for developers who still use the old version SDK.

See the API diff from iOS 11 SDK to iOS 12 SDK, here they change the define and add new types: http://codeworkshop.net/objc-diff/sdkdiffs/ios/12.0/QuartzCore.html

> CAGradientLayer.h
+ Added CAGradientLayerType
+ Added kCAGradientLayerRadial
+ Added kCAGradientLayerConic

@adamgit 