### PR TITLE
Add Travis CI support, build all the scheme (iOS/tvOS/macOS) and iOS/macOS demo to ensure build success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+
+language: objective-c
+osx_image: xcode9.4
+
+env:
+  global:
+    - LC_CTYPE=en_US.UTF-8
+    - LANG=en_US.UTF-8
+
+notifications:
+  email: false
+
+before_install:
+    - env
+    - locale
+    - gem install cocoapods --no-rdoc --no-ri --no-document --quiet
+    - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+    - pod --version
+    - pod setup --silent > /dev/null
+    - pod repo update --silent
+    - xcpretty --version
+    - xcodebuild -version
+    - xcodebuild -showsdks
+
+script:
+    - set -o pipefail
+
+    - echo Check if the library described by the podspec can be built
+    - pod lib lint --allow-warnings
+
+    - echo Build as static library
+    - xcodebuild build -project SVGKit-iOS.xcodeproj -scheme 'SVGKit-iOS' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
+
+    - echo Build as dynamic frameworks
+    - xcodebuild build clean -project SVGKit-iOS.xcodeproj -scheme 'SVGKitFramework-iOS' -sdk iphonesimulator PLATFORM_NAME=iphonesimulator -configuration Debug | xcpretty -c
+    - xcodebuild build clean -project SVGKit-iOS.xcodeproj -scheme 'SVGKitFramework-tvOS' -sdk appletvsimulator -configuration Debug | xcpretty -c
+    - xcodebuild build clean -project SVGKit-iOS.xcodeproj -scheme 'SVGKitFramework-OSX' -sdk macosx -configuration Debug | xcpretty -c
+
+    - echo Build the Demo apps
+    - xcodebuild build -project Demo-iOS.xcodeproj -scheme 'Demo-iOS' -configuration Debug -destination 'name=iPhone 8' | xcpretty -c
+    - xcodebuild build -project Demo-OSX.xcodeproj -scheme 'Demo-OSX' -sdk macosx -configuration Debug | xcpretty -c


### PR DESCRIPTION
This is imporatant for maintainer, to avoid the contributors's mistake or silly issue cause compile failed for user. Like my mistake and take #594 to fix.

It's simple to enable Travis-CI support. Just go to https://travis-ci.org/SVGKit/SVGKit/ . Sign in and turn on the CI support. (Because I'm not the member of SVGKit organization)

I've also tested the travis config file and make it pass the build process via my fork repo here: https://travis-ci.org/dreampiggy/SVGKit/builds

Since this only change one config file which is not related to code. I think it can be merged at any time. I hope this can be done before my last commit to release 2.1.0. (Need update podspec && Xcode config).