### PR TITLE
All init method should call `populateFromImage` to correctly setup the layer class (layer-backed or layer-hosting)

### DIFF
--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -39,12 +39,7 @@
 	self = [super initWithFrame:frame];
 	if( self )
 	{
-#if SVGKIT_UIKIT
-		self.backgroundColor = [UIColor clearColor];
-#else
-        self.layer.backgroundColor = [NSColor clearColor].CGColor;
-#endif
-        
+        [self populateFromImage:nil];
 	}
 	return self;
 }

--- a/Source/UIKit additions/SVGKLayeredImageView.m
+++ b/Source/UIKit additions/SVGKLayeredImageView.m
@@ -46,11 +46,7 @@
 	self = [super initWithFrame:frame];
 	if( self )
 	{
-#if SVGKIT_UIKIT
-		self.backgroundColor = [UIColor clearColor];
-#else
-        self.layer.backgroundColor = [NSColor clearColor].CGColor;
-#endif
+        [self populateFromImage:nil];
 	}
 	return self;
 }


### PR DESCRIPTION
This fix issue if user write this case (really common and no warning):

```objective-c
SVGKImageView *imageView = [SVGKImageView alloc] initWithFrame:frame];
```

Or using storyboard on macOS. Because the `layerClass` is not correct been setup (The setup logic is inside `populateFromImage:`). So it wll not use `SVGKLayer` but the AppKit default layer. And then cause a runtime crash.