### PR TITLE
Use a better solution to solve macOS's flip of <image> && <text> contents

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -250,6 +250,14 @@
 		327B2897217DAC77004D27FC /* SVGRadialGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5DE2176E01400ED20D8 /* SVGRadialGradientElement.m */; };
 		32A1F09F21746F4700ABFCE1 /* SVGKitFramework_OSXTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 32A1F09E21746F4700ABFCE1 /* SVGKitFramework_OSXTests.m */; };
 		32A1F0A121746F4700ABFCE1 /* SVGKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 321EAA622171EC8700640504 /* SVGKit.framework */; };
+		32C4891E21916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C4891F21916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C4892021916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C4892121916F3D007B1F29 /* SVGTextLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C4891C21916F3D007B1F29 /* SVGTextLayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		32C4892221916F3D007B1F29 /* SVGTextLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C4891D21916F3D007B1F29 /* SVGTextLayer.m */; };
+		32C4892321916F3D007B1F29 /* SVGTextLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C4891D21916F3D007B1F29 /* SVGTextLayer.m */; };
+		32C4892421916F3D007B1F29 /* SVGTextLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C4891D21916F3D007B1F29 /* SVGTextLayer.m */; };
+		32C4892521916F3D007B1F29 /* SVGTextLayer.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C4891D21916F3D007B1F29 /* SVGTextLayer.m */; };
 		32D3D5D72176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
 		32D3D5D82176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
 		32D3D5D92176E00E00ED20D8 /* SVGLinearGradientElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */; };
@@ -1027,6 +1035,8 @@
 		32A1F09C21746F4700ABFCE1 /* SVGKitFramework-OSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SVGKitFramework-OSXTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		32A1F09E21746F4700ABFCE1 /* SVGKitFramework_OSXTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVGKitFramework_OSXTests.m; sourceTree = "<group>"; };
 		32A1F0A021746F4700ABFCE1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		32C4891C21916F3D007B1F29 /* SVGTextLayer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGTextLayer.h; sourceTree = "<group>"; };
+		32C4891D21916F3D007B1F29 /* SVGTextLayer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SVGTextLayer.m; sourceTree = "<group>"; };
 		32D3D5D52176E00D00ED20D8 /* SVGLinearGradientElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SVGLinearGradientElement.m; sourceTree = "<group>"; };
 		32D3D5D62176E00D00ED20D8 /* SVGLinearGradientElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGLinearGradientElement.h; sourceTree = "<group>"; };
 		32D3D5DD2176E01400ED20D8 /* SVGRadialGradientElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SVGRadialGradientElement.h; sourceTree = "<group>"; };
@@ -1889,6 +1899,8 @@
 				6636CD89175F54680072AAEF /* CALayer+RecursiveClone.m */,
 				9ED79A22179D87790048AA5B /* SVGGradientLayer.h */,
 				9ED79A23179D87790048AA5B /* SVGGradientLayer.m */,
+				32C4891C21916F3D007B1F29 /* SVGTextLayer.h */,
+				32C4891D21916F3D007B1F29 /* SVGTextLayer.m */,
 				BD2F8C53199D14D6008AE06D /* CALayerWithClipRender.h */,
 				BD2F8C54199D14D6008AE06D /* CALayerWithClipRender.m */,
 				BD4C56DA199D55CC00AF04AD /* CAShapeLayerWithClipRender.h */,
@@ -1939,6 +1951,7 @@
 				321EAA7C2171ED6900640504 /* CSSStyleSheet.h in Headers */,
 				321EAAD82171ED6F00640504 /* SVGFitToViewBox.h in Headers */,
 				321EAB4D2171ED9E00640504 /* NSData+NSInputStream.h in Headers */,
+				32C4892121916F3D007B1F29 /* SVGTextLayer.h in Headers */,
 				321EAB1B2171ED8D00640504 /* SVGKParserDefsAndUse.h in Headers */,
 				321EAAB32171ED6F00640504 /* SVGClipPathElement.h in Headers */,
 				321EAAC52171ED6F00640504 /* SVGMatrix.h in Headers */,
@@ -2093,6 +2106,7 @@
 				66E863AC1688C2780059C9C4 /* DocumentFragment.h in Headers */,
 				66372EEF1695F17F008C6C56 /* DocumentStyle.h in Headers */,
 				66E863AE1688C2780059C9C4 /* DocumentType.h in Headers */,
+				32C4891E21916F3D007B1F29 /* SVGTextLayer.h in Headers */,
 				66E863B01688C2780059C9C4 /* DOMHelperUtilities.h in Headers */,
 				66E863B21688C2780059C9C4 /* Element.h in Headers */,
 				66E863B41688C2780059C9C4 /* EntityReference.h in Headers */,
@@ -2231,6 +2245,7 @@
 				825CDB061BDA5057003C1C12 /* CSSValue.h in Headers */,
 				32D3D5DB2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */,
 				825CDB071BDA5057003C1C12 /* Document+Mutable.h in Headers */,
+				32C4891F21916F3D007B1F29 /* SVGTextLayer.h in Headers */,
 				825CDB081BDA5057003C1C12 /* Document.h in Headers */,
 				825CDB091BDA5057003C1C12 /* DocumentCSS.h in Headers */,
 				825CDB0A1BDA5057003C1C12 /* DocumentStyle.h in Headers */,
@@ -2369,6 +2384,7 @@
 				825CDB861BDA50B3003C1C12 /* CSSValue.h in Headers */,
 				32D3D5DC2176E00E00ED20D8 /* SVGLinearGradientElement.h in Headers */,
 				825CDB871BDA50B3003C1C12 /* Document+Mutable.h in Headers */,
+				32C4892021916F3D007B1F29 /* SVGTextLayer.h in Headers */,
 				825CDB881BDA50B3003C1C12 /* Document.h in Headers */,
 				825CDB891BDA50B3003C1C12 /* DocumentCSS.h in Headers */,
 				825CDB8A1BDA50B3003C1C12 /* DocumentStyle.h in Headers */,
@@ -2771,6 +2787,7 @@
 				321EAB692172029800640504 /* SVGKFastImageView.m in Sources */,
 				321EAB6A2172029800640504 /* SVGKImageView.m in Sources */,
 				321EAB6B2172029800640504 /* SVGKLayeredImageView.m in Sources */,
+				32C4892521916F3D007B1F29 /* SVGTextLayer.m in Sources */,
 				321EAADA2171ED6F00640504 /* SVGTextPositioningElement.m in Sources */,
 				321EAAC42171ED6F00640504 /* SVGLength.m in Sources */,
 				321EAB0A2171ED7E00640504 /* TinySVGTextAreaElement.m in Sources */,
@@ -2900,6 +2917,7 @@
 				66E863A61688C2780059C9C4 /* CharacterData.m in Sources */,
 				66E863A81688C2780059C9C4 /* Comment.m in Sources */,
 				66E863AB1688C2780059C9C4 /* Document.m in Sources */,
+				32C4892221916F3D007B1F29 /* SVGTextLayer.m in Sources */,
 				66E863AD1688C2780059C9C4 /* DocumentFragment.m in Sources */,
 				66E863AF1688C2780059C9C4 /* DocumentType.m in Sources */,
 				66E863B11688C2780059C9C4 /* DOMHelperUtilities.m in Sources */,
@@ -3008,6 +3026,7 @@
 				825CDBFB1BDA511C003C1C12 /* Comment.m in Sources */,
 				825CDBFC1BDA511C003C1C12 /* CSSStyleDeclaration.m in Sources */,
 				825CDBFD1BDA511C003C1C12 /* CSSRule.m in Sources */,
+				32C4892321916F3D007B1F29 /* SVGTextLayer.m in Sources */,
 				825CDBFE1BDA511C003C1C12 /* CSSStyleRule.m in Sources */,
 				825CDBFF1BDA511C003C1C12 /* CSSStyleSheet.m in Sources */,
 				825CDC001BDA511C003C1C12 /* CSSRuleList.m in Sources */,
@@ -3124,6 +3143,7 @@
 				825CDC5F1BDA5144003C1C12 /* Comment.m in Sources */,
 				825CDC601BDA5144003C1C12 /* CSSStyleDeclaration.m in Sources */,
 				825CDC611BDA5144003C1C12 /* CSSRule.m in Sources */,
+				32C4892421916F3D007B1F29 /* SVGTextLayer.m in Sources */,
 				825CDC621BDA5144003C1C12 /* CSSStyleRule.m in Sources */,
 				825CDC631BDA5144003C1C12 /* CSSStyleSheet.m in Sources */,
 				825CDC641BDA5144003C1C12 /* CSSRuleList.m in Sources */,

--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -5,6 +5,7 @@
 #import "SVGGradientLayer.h"
 #import "SVGHelperUtilities.h"
 #import "SVGUtils.h"
+#import "SVGTextLayer.h"
 
 @implementation SVGTextElement
 
@@ -118,7 +119,7 @@
 											  suggestedUntransformedSize.width,
 											  suggestedUntransformedSize.height); // everything's been pre-scaled by [self transformAbsolute]
 	
-    CATextLayer *label = [[CATextLayer alloc] init];
+    CATextLayer *label = [SVGTextLayer layer];
     [SVGHelperUtilities configureCALayer:label usingElement:self];
 	
 	/** This is complicated for three reasons.

--- a/Source/Exporters/SVGKImage+CGContext.m
+++ b/Source/Exporters/SVGKImage+CGContext.m
@@ -30,10 +30,7 @@
 
 - (void)renderInContext:(CGContextRef)ctx
 {
-    CALayer *layerTree = self.CALayerTree;
-    [self temporaryWorkaroundPreprocessRenderingLayerTree:layerTree];
-	[layerTree renderInContext:ctx];
-    [self temporaryWorkaroundPostProcessRenderingLayerTree:layerTree];
+	[self.CALayerTree renderInContext:ctx];
 }
 
 /**
@@ -96,53 +93,6 @@
 		[perfImprovements appendString:@"NONE"];
 	
 	SVGKitLogVerbose(@"[%@] renderToContext: time taken to render CALayers to CGContext (perf improvements:%@): %2.3f seconds)", [self class], perfImprovements, -1.0f * [startTime timeIntervalSinceNow] );
-}
-
-/**
- macOS (at least macOS 10.13 still exist) contains bug in `-[CALayer renderInContext:]` method for `CATextLayer` or `CALayer` with CGImage contents
- which will use flipped coordinate system to draw text/image content. However, iOS/tvOS works fine. We have to hack to fix it. :)
- note when using sublayer drawing (`USE_SUBLAYERS_INSTEAD_OF_BLIT` = 1) this issue disappear
-
- @param layerTree layerTree
- */
-- (void)temporaryWorkaroundPreprocessRenderingLayerTree:(CALayer *)layerTree {
-#if SVGKIT_MAC
-    BOOL fixFlip = NO;
-    if ([layerTree isKindOfClass:[CATextLayer class]]) {
-        fixFlip = YES;
-    } else if (layerTree.contents != nil) {
-        fixFlip = YES;
-    }
-    if (fixFlip) {
-        // Hack to apply flip for content
-        NSAffineTransform *flip = [NSAffineTransform transform];
-        [flip translateXBy:0 yBy:layerTree.bounds.size.height];
-        [flip scaleXBy:1.0 yBy:-1.0];
-        [layerTree setValue:flip forKey:@"contentsTransform"];
-    }
-    for (CALayer *layer in layerTree.sublayers) {
-        [self temporaryWorkaroundPreprocessRenderingLayerTree:layer];
-    }
-#endif
-}
-
-- (void)temporaryWorkaroundPostProcessRenderingLayerTree:(CALayer *)layerTree {
-#if SVGKIT_MAC
-    BOOL fixFlip = NO;
-    if ([layerTree isKindOfClass:[CATextLayer class]]) {
-        fixFlip = YES;
-    } else if (layerTree.contents != nil) {
-        fixFlip = YES;
-    }
-    if (fixFlip) {
-        // Hack to recover flip for content
-        NSAffineTransform *flip = [NSAffineTransform transform];
-        [layerTree setValue:flip forKey:@"contentsTransform"];
-    }
-    for (CALayer *layer in layerTree.sublayers) {
-        [self temporaryWorkaroundPostProcessRenderingLayerTree:layer];
-    }
-#endif
 }
 
 @end

--- a/Source/QuartzCore additions/CALayerWithClipRender.m
+++ b/Source/QuartzCore additions/CALayerWithClipRender.m
@@ -8,6 +8,12 @@
 
 #import "CALayerWithClipRender.h"
 
+@interface CALayer (ContentsTransform)
+
+@property CGAffineTransform contentsTransform;
+
+@end
+
 @implementation CALayerWithClipRender
 
 - (void)renderInContext:(CGContextRef)ctx {
@@ -19,7 +25,19 @@
         self.mask = nil;
     }
     
+    // We use the flipped coordinate system on macOS, to match the behavior of iOS. However, the `contents` (which is a CGImageRef) bitmap provided by image element is not been flipped as we want. The `renderInContext:` which used by `SVGKFastImageView` will not correct this coordinate system issue, only `SVGKLayeredImageView` do. So we use the `contentsTransform` to manually fix it.
+#if SVGKIT_MAC
+    // If already flipped, which should be handled by Core Animation itself, ignore
+    if (self.contentsAreFlipped) {
+        [super renderInContext:ctx];
+    } else {
+        self.contentsTransform = CGAffineTransformMake(1, 0, 0, -1, 0, self.bounds.size.height);
+        [super renderInContext:ctx];
+        self.contentsTransform = CGAffineTransformIdentity;
+    }
+#else
     [super renderInContext:ctx];
+#endif
     
     if( mask != nil ) {
         self.mask = mask;

--- a/Source/QuartzCore additions/SVGTextLayer.h
+++ b/Source/QuartzCore additions/SVGTextLayer.h
@@ -1,0 +1,17 @@
+//
+//  SVGTextLayer.h
+//  SVGKit-iOS
+//
+//  Created by lizhuoli on 2018/11/6.
+//  Copyright © 2018 na. All rights reserved.
+//
+
+#import <QuartzCore/QuartzCore.h>
+
+/**
+ On macOS, we use the flipped coordinate system. However, Apple's `CATextLayer` render the text using `contentsAreFlipped` property. Which is set to NO and this will cause the text element been drawn flipped unlike what it's drawn on iOS. We use this subclass to override that value on macOS.
+ Besides this fix, this class may also implement more features to match the SVG spec in the future, such as gradient stroke (which currently is not supported)
+ */
+@interface SVGTextLayer : CATextLayer
+
+@end

--- a/Source/QuartzCore additions/SVGTextLayer.m
+++ b/Source/QuartzCore additions/SVGTextLayer.m
@@ -1,0 +1,22 @@
+//
+//  SVGTextLayer.m
+//  SVGKit-iOS
+//
+//  Created by lizhuoli on 2018/11/6.
+//  Copyright © 2018 na. All rights reserved.
+//
+
+#import "SVGTextLayer.h"
+#import "SVGKDefine.h"
+
+@implementation SVGTextLayer
+
+- (BOOL)contentsAreFlipped {
+#if SVGKIT_MAC
+    return YES;
+#else
+    return [super contentsAreFlipped];
+#endif
+}
+
+@end

--- a/Source/SVGKit.h
+++ b/Source/SVGKit.h
@@ -155,6 +155,7 @@ FOUNDATION_EXPORT const unsigned char SVGKitFramework_VersionString[];
 #import "SVGKPointsAndPathsParser.h"
 #import "CALayer+RecursiveClone.h"
 #import "SVGGradientLayer.h"
+#import "SVGTextLayer.h"
 #import "CALayerWithChildHitTest.h"
 #import "CAShapeLayerWithHitTest.h"
 #import "CGPathAdditions.h"

--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -39,12 +39,7 @@
 	self = [super initWithFrame:frame];
 	if( self )
 	{
-#if SVGKIT_UIKIT
-		self.backgroundColor = [UIColor clearColor];
-#else
-        self.layer.backgroundColor = [NSColor clearColor].CGColor;
-#endif
-        
+        [self populateFromImage:nil];
 	}
 	return self;
 }

--- a/Source/UIKit additions/SVGKLayeredImageView.m
+++ b/Source/UIKit additions/SVGKLayeredImageView.m
@@ -46,11 +46,7 @@
 	self = [super initWithFrame:frame];
 	if( self )
 	{
-#if SVGKIT_UIKIT
-		self.backgroundColor = [UIColor clearColor];
-#else
-        self.layer.backgroundColor = [NSColor clearColor].CGColor;
-#endif
+        [self populateFromImage:nil];
 	}
 	return self;
 }


### PR DESCRIPTION
Don't need to recursive check and hack for that transform

## What's for

This solution provide a better way, instead of current hack for macOS. See that `temporaryWorkaroundPreprocessRenderingLayerTree:` method.

The reason, is that we use the iOS flipped coordinate system on macOS, instead of native bottom-left coordinate system (Because it can simplify cross-platform code). This works for most of rendering of vector element, because there are a global transform from AppKit. However, for the bitmap or texture element like `<image>` && `<text>`, They are kept into the default coordinate system (bottom-left), so the final render result will cause them been flipped. 

Note this only happened to `SVGKFastImageView` software rendering, while `SVGKLayeredImageView` already handle this case. Good Apple :)

## The solution

For text element rendering in `CATextLayer`, it can override that `contentsAreFlipped` property to use the flipped coordinate system.

For image element, there are no obvious way to do so, we still use the `contentsTransform` property. (Actually, the CALayer set a flag in CALayer->_ivars to indicate it's flipped , but it's hard to use that than `contentsTransform`, so I still use this one, same effect)

This solution is better than the current one, which do not need to recursive check each sublayers. Just render them on demand.

@adamgit 