### PR TITLE
fix: app crashed on iPad Pro 3rd generation

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -209,7 +209,8 @@ static float cachedDevicePixelsPerInch;
 	|| [platform hasPrefix:@"iPad5,3"]
     || [platform hasPrefix:@"iPad5,4"]
 	|| [platform hasPrefix:@"iPad6"]
-    || [platform hasPrefix:@"iPad7"])
+    || [platform hasPrefix:@"iPad7"]
+    || [platform hasPrefix:@"iPad8"])
 		return 264.0f;
     
 	if( [platform hasPrefix:@"iPad"]) // catch-all for higher-end devices not yet existing


### PR DESCRIPTION
The `pixelsPerInchForCurrentDevice` didn't had value for iPads with prefix iPad8