### PR TITLE
Feature: optional custom cache name on SVGKImage init

### DIFF
--- a/Source/SVGKImage.h
+++ b/Source/SVGKImage.h
@@ -88,7 +88,9 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVG
  - Creates an SVGKSource so that you can later inspect exactly where it found the file
  */
 + (SVGKImage *)imageNamed:(NSString *)name;
++ (SVGKImage *)imageNamed:(NSString *)name withCacheKey:(NSString *)key;
 + (SVGKImage *)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle;
++ (SVGKImage *)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle withCacheKey:(NSString *)key;
 /**
  Almost identical to imageNamed: except that it performs the parse in a separate thread.
  
@@ -310,5 +312,6 @@ typedef void (^SVGKImageAsynchronousLoadingDelegate)(SVGKImage* loadedImage, SVG
 
 /** alters the SVG image's size directly (by changing the viewport) so that it will fit inside the specifed area without stretching or deforming */
 -(void) scaleToFitInside:(CGSize) maxSize;
++(void) clearCache;
 
 @end

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -87,7 +87,6 @@ static NSMutableDictionary* globalSVGKImageCache;
 	SVGKitLogWarn(@"[%@] Low-mem, background or api clear; purging cache of %lu SVGKImages...", self, (unsigned long)[globalSVGKImageCache count] );
 	
 	[globalSVGKImageCache removeAllObjects]; // once they leave the cache, if they are no longer referred to, they should automatically dealloc
-    [self didReceiveMemoryWarningOrBackgroundNotification: nil];
 }
 
 +(void) didReceiveMemoryWarningOrBackgroundNotification:(NSNotification*) notification

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -82,16 +82,17 @@ static NSMutableDictionary* globalSVGKImageCache;
 }
 
 +(void) clearCache {
-    [self didReceiveMemoryWarningOrBackgroundNotification: nil];
-}
-
-+(void) didReceiveMemoryWarningOrBackgroundNotification:(NSNotification*) notification
-{
 	if ([globalSVGKImageCache count] == 0) return;
 	
 	SVGKitLogWarn(@"[%@] Low-mem, background or api clear; purging cache of %lu SVGKImages...", self, (unsigned long)[globalSVGKImageCache count] );
 	
 	[globalSVGKImageCache removeAllObjects]; // once they leave the cache, if they are no longer referred to, they should automatically dealloc
+    [self didReceiveMemoryWarningOrBackgroundNotification: nil];
+}
+
++(void) didReceiveMemoryWarningOrBackgroundNotification:(NSNotification*) notification
+{
+	[self clearCache];
 }
 #endif
 
@@ -114,7 +115,7 @@ static NSMutableDictionary* globalSVGKImageCache;
 + (SVGKImage *)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle withCacheKey:(NSString *)key
 {	
 #if ENABLE_GLOBAL_IMAGE_CACHE_FOR_SVGKIMAGE_IMAGE_NAMED
-    NSString* cacheName = [name stringByAppendingString:key];
+    NSString* cacheName = [key length] > 0 ? key : name;
     if( globalSVGKImageCache == nil )
     {
         globalSVGKImageCache = [NSMutableDictionary new];


### PR DESCRIPTION
I am wrapping up an integration with React Native and needed a way to customize the cache key name and reset the cache as needed.

Checked these changes against the Demo-iOS project and found everything working. This PR  increases init API surface on SVGKImage, ~and concats any customKey string with the svg name~ by adding additional init methods that will take a cache key as a parameter.

_added_
+(void) clearCache public method for  +(void) didReceiveMemoryWarningOrBackgroundNotification

+(SVGKImage *)imageNamed:(NSString *)name withCacheKey:(NSString *)key

_modified_
+(SVGKImage *)imageNamed:(NSString *)name inBundle:(NSBundle *)bundle withCacheKey:(NSString *)key
checks for `key` and uses that as the cache key, if none is provided then `name` is used as the cache key as before

didn't see a need to include an svg for this.