### PR TITLE
# SVGElement position issue addressed.

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -158,12 +158,12 @@
     NSString* pos_y = [self getAttribute:@"y"];
     
     if (pos_x == nil || pos_x.length < 1)
-        self.x = nil;
+        self.x = 0; // i.e. undefined
     else
         self.x = [SVGLength svgLengthFromNSString:pos_x];
     
     if (pos_y == nil || pos_y.length < 1)
-        self.y = nil;
+        self.y = 0; // i.e. undefined
     else
         self.y = [SVGLength svgLengthFromNSString:pos_y];
     

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -154,6 +154,19 @@
 	NSString* stringWidth = [self getAttribute:@"width"];
 	NSString* stringHeight = [self getAttribute:@"height"];
 	
+    NSString* pos_x = [self getAttribute:@"x"];
+    NSString* pos_y = [self getAttribute:@"y"];
+    
+    if (pos_x == nil || pos_x.length < 1)
+        self.x = nil;
+    else
+        self.x = [SVGLength svgLengthFromNSString:pos_x];
+    
+    if (pos_y == nil || pos_y.length < 1)
+        self.y = nil;
+    else
+        self.y = [SVGLength svgLengthFromNSString:pos_y];
+    
 	if( stringWidth == nil || stringWidth.length < 1 )
 		self.width = nil; // i.e. undefined
 	else
@@ -178,8 +191,12 @@
 		self.height = nil;
 	
 	/* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
-	if( self.width != nil && self.height != nil )
-		self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
+    if( self.width != nil && self.height != nil && self.x != nil && self.y != nil)
+        
+        self.requestedViewport = SVGRectMake([self.x pixelsValue],
+                                             [self.y pixelsValue],
+                                             [self.width pixelsValue],
+                                             [self.height pixelsValue]);
 	else
 		self.requestedViewport = SVGRectUninitialized();
 	

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -192,7 +192,7 @@
 	
     /* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
     if( self.width != nil && self.height != nil )
-        self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
+        self.requestedViewport = SVGRectMake( [self.x pixelsValue], [self.y pixelsValue], [self.width pixelsValue], [self.height pixelsValue] );
     else
         self.requestedViewport = SVGRectUninitialized();
 	

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -191,7 +191,7 @@
 		self.height = nil;
 	
 	/* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
-    if( self.width != nil && self.height != nil && self.x != nil && self.y != nil)
+    if( self.width != nil && self.height != nil )
         
         self.requestedViewport = SVGRectMake([self.x pixelsValue],
                                              [self.y pixelsValue],

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -192,11 +192,7 @@
 	
 	/* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
     if( self.width != nil && self.height != nil )
-        
-        self.requestedViewport = SVGRectMake([self.x pixelsValue],
-                                             [self.y pixelsValue],
-                                             [self.width pixelsValue],
-                                             [self.height pixelsValue]);
+        self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
 	else
 		self.requestedViewport = SVGRectUninitialized();
 	

--- a/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGSVGElement.m
@@ -190,11 +190,11 @@
 	if( self.height.unitType == SVG_LENGTHTYPE_PERCENTAGE )
 		self.height = nil;
 	
-	/* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
+    /* set the frameRequestedViewport appropriately (NB: spec doesn't allow for this but it REQUIRES it to be done and saved!) */
     if( self.width != nil && self.height != nil )
         self.requestedViewport = SVGRectMake( 0, 0, [self.width pixelsValue], [self.height pixelsValue] );
-	else
-		self.requestedViewport = SVGRectUninitialized();
+    else
+        self.requestedViewport = SVGRectUninitialized();
 	
 	
 	/**


### PR DESCRIPTION
- Considered origin x & y for **svg** element.

Notes : I would like add few points.

- I was wondering why we simply ignored  **x_Pos** & **y_Pos** for element. I figured it out we are silently ignoring position value. I created PR with changes, let me know your thoughts.
- I am using svg with multiple embedded **svg** .