### PR TITLE
Fix macOS layer observer crash

### DIFF
--- a/Source/UIKit additions/SVGKFastImageView.m
+++ b/Source/UIKit additions/SVGKFastImageView.m
@@ -113,8 +113,10 @@
 -(void) removeInternalRedrawOnResizeObservers
 {
   if (!self.didRegisterInternalRedrawObservers) return;
-	[self removeObserver:self  forKeyPath:@"layer" context:(__bridge void * _Nullable)(internalContextPointerBecauseApplesDemandsIt)];
+	[self removeObserver:self forKeyPath:@"layer" context:(__bridge void * _Nullable)(internalContextPointerBecauseApplesDemandsIt)];
+#if !SVGKIT_MAC || USE_SUBLAYERS_INSTEAD_OF_BLIT
 	[self.layer removeObserver:self forKeyPath:@"transform" context:(__bridge void * _Nullable)(internalContextPointerBecauseApplesDemandsIt)];
+#endif
   self.didRegisterInternalRedrawObservers = false;
 }
 


### PR DESCRIPTION
In macOS, the `SVGKFastImageView` may not have a `layer` property value when its `image` property is set.

When deallocated, the `SVGKFastImageView` may have a `_NSViewBackingLayer` set to its `layer` property.

We must avoid calling `removeObserver:` on the layer unless `wantsLayer` is being used. Otherwise, the application will crash when trying to remove `self` as an observer when it isn't actually observing.