### PR TITLE
fix operation error

### DIFF
--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -854,7 +854,11 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
 		
 		numerator = MAX(0, numerator);
 		
-		lhs = sign * sqrt(numerator/denom);
+        if (denom == 0) {
+            lhs = 0;
+         }else {
+             lhs = sign * sqrt(numerator/denom);
+         }
 	}
 	
 	CGFloat cxp = lhs * (rx*y1p)/ry;


### PR DESCRIPTION
I'm find 'SVGKPointsAndPathsParser.m line:857' has bug.
'denom' may be zero, it will cause an operation error.
I have fix it like this :
if (denom == 0) { lhs = 0; }else { lhs = sign * sqrt(numerator/denom); }