### PR TITLE
Fixes crash

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -675,39 +675,41 @@ static NSMutableDictionary* globalSVGKImageCache;
     /**
      Special handling for clip-path; need to create their children
      */
-    NSString* clipPath = [element cascadedValueForStylableProperty:@"clip-path" inherit:NO];
-    if ( [clipPath hasPrefix:@"url"] )
-    {
-        NSRange idKeyRange = NSMakeRange(5, clipPath.length - 6);
-        NSString* _pathId = [clipPath substringWithRange:idKeyRange];
-        
-        /** Replace the return layer with a special layer using the URL fill */
-        /** fetch the fill layer by URL using the DOM */
-        NSAssert( element.rootOfCurrentDocumentFragment != nil, @"This SVG shape has a URL clip-path type; it needs to search for that URL (%@) inside its nearest-ancestor <SVG> node, but the rootOfCurrentDocumentFragment reference was nil (suggests the parser failed, or the SVG file is corrupt)", _pathId );
-        
-        SVGClipPathElement* clipPathElement = (SVGClipPathElement*) [element.rootOfCurrentDocumentFragment getElementById:_pathId];
-        NSAssert( clipPathElement != nil, @"This SVG shape has a URL clip-path (%@), but could not find an XML Node with that ID inside the DOM tree (suggests the parser failed, or the SVG file is corrupt)", _pathId );
-        
-        CALayer *clipLayer = [clipPathElement newLayer];
-        for (SVGElement *child in clipPathElement.childNodes )
+    if ( [element respondsToSelector:@selector(cascadedValueForStylableProperty:inherit:)] ) {
+        NSString* clipPath = [element cascadedValueForStylableProperty:@"clip-path" inherit:NO];
+        if ( [clipPath hasPrefix:@"url"] )
         {
-            if ([child conformsToProtocol:@protocol(ConverterSVGToCALayer)]) {
-                
-                CALayer *sublayer = [self newLayerWithElement:(SVGElement<ConverterSVGToCALayer> *)child];
-                
-                if (!sublayer) {
-                    continue;
+            NSRange idKeyRange = NSMakeRange(5, clipPath.length - 6);
+            NSString* _pathId = [clipPath substringWithRange:idKeyRange];
+
+            /** Replace the return layer with a special layer using the URL fill */
+            /** fetch the fill layer by URL using the DOM */
+            NSAssert( element.rootOfCurrentDocumentFragment != nil, @"This SVG shape has a URL clip-path type; it needs to search for that URL (%@) inside its nearest-ancestor <SVG> node, but the rootOfCurrentDocumentFragment reference was nil (suggests the parser failed, or the SVG file is corrupt)", _pathId );
+
+            SVGClipPathElement* clipPathElement = (SVGClipPathElement*) [element.rootOfCurrentDocumentFragment getElementById:_pathId];
+            NSAssert( clipPathElement != nil, @"This SVG shape has a URL clip-path (%@), but could not find an XML Node with that ID inside the DOM tree (suggests the parser failed, or the SVG file is corrupt)", _pathId );
+
+            CALayer *clipLayer = [clipPathElement newLayer];
+            for (SVGElement *child in clipPathElement.childNodes )
+            {
+                if ([child conformsToProtocol:@protocol(ConverterSVGToCALayer)]) {
+
+                    CALayer *sublayer = [self newLayerWithElement:(SVGElement<ConverterSVGToCALayer> *)child];
+
+                    if (!sublayer) {
+                        continue;
+                    }
+
+                    [clipLayer addSublayer:sublayer];
                 }
-                
-                [clipLayer addSublayer:sublayer];
             }
+
+            [clipPathElement layoutLayer:clipLayer toMaskLayer:layer];
+
+            SVGKitLogWarn(@"DOESNT WORK, APPLE's API APPEARS BROKEN???? - About to mask layer frame (%@) with a mask of frame (%@)", NSStringFromCGRect(layer.frame), NSStringFromCGRect(clipLayer.frame));
+            layer.mask = clipLayer;
+             // because it was created with a +1 retain count
         }
-        
-        [clipPathElement layoutLayer:clipLayer toMaskLayer:layer];
-        
-        SVGKitLogWarn(@"DOESNT WORK, APPLE's API APPEARS BROKEN???? - About to mask layer frame (%@) with a mask of frame (%@)", NSStringFromCGRect(layer.frame), NSStringFromCGRect(clipLayer.frame));
-        layer.mask = clipLayer;
-         // because it was created with a +1 retain count
     }
 	
 	/**


### PR DESCRIPTION
Fixes crash on sending message -[Element cascadedValueForStylableProp…erty:inherit:] which element doesn't respond while rendering file ![](http://w7software.com/downloads/output1.svg).

It solves crash #631 but doesn't solve issue rendering this file as I can't still see this image rendered on screen of iOS device.