### PR TITLE
Fix the crash issue #551 by using the instance property instead of static variable.

### DIFF
--- a/Source/Parsers/Parser Extensions/SVGKParserGradient.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserGradient.m
@@ -16,24 +16,25 @@
 #import "SVGLinearGradientElement.h"
 #import "SVGRadialGradientElement.h"
 
+@interface SVGKParserGradient ()
+@property (nonatomic) NSArray *supportedNamespaces;
+@property (nonatomic) NSArray *supportedTags;
+@end
+
 @implementation SVGKParserGradient
 
-//-(NSSet*) supportedNamespaces
-//{
-//    if( self->_supportedNamespaces == nil )
-//        self->_supportedNamespaces = [[NSSet alloc] initWithObjects:
-//                        @"http://www.w3.org/2000/svg",
-//                        nil];
-//	return self->_supportedNamespaces;
-//}
-
-static NSSet *_svgGradientParserSupportedTags = nil;
--(NSSet *)supportedTags
+-(NSArray *)supportedNamespaces
 {
-//    static NSSet *supportedTags = nil;
-    if( _svgGradientParserSupportedTags == nil )
-        _svgGradientParserSupportedTags = [[NSSet alloc] initWithObjects:@"linearGradient", @"radialGradient", @"stop", nil];
-    return _svgGradientParserSupportedTags;
+    if( _supportedNamespaces == nil )
+        _supportedNamespaces = @[@"http://www.w3.org/2000/svg"];
+    return _supportedNamespaces;
+}
+
+-(NSArray *)supportedTags
+{
+    if( _supportedTags == nil )
+        _supportedTags = @[@"linearGradient", @"radialGradient", @"stop"];
+    return _supportedTags;
 }
 
 -(Node *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node *)parentNode
@@ -95,12 +96,6 @@ static NSSet *_svgGradientParserSupportedTags = nil;
 //    currentElement = nil;
 //    [super dealloc];
 //}
-
-
-+(void)trim
-{
-    _svgGradientParserSupportedTags = nil;
-}
 
 
 @end

--- a/Source/Parsers/Parser Extensions/SVGKParserSVG.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserSVG.m
@@ -21,57 +21,55 @@
 
 #import "SVGDocument_Mutable.h"
 
+@interface SVGKParserSVG ()
+@property (nonatomic) NSArray *supportedNamespaces;
+@property (nonatomic) NSDictionary *elementMap;
+@end
+
 @implementation SVGKParserSVG
 
-static NSDictionary *elementMap;
-
-- (id)init {
-	self = [super init];
-	if (self) {
-		
-		if (!elementMap) {
-			elementMap = [NSDictionary dictionaryWithObjectsAndKeys:
-						   [SVGSVGElement class], @"svg",
-                          [SVGCircleElement class], @"circle",
-                          [SVGDescriptionElement class], @"description",
-                          [SVGEllipseElement class], @"ellipse",
-                          [SVGGElement class], @"g",
-                          [SVGClipPathElement class], @"clipPath",
-                          [SVGImageElement class], @"image",
-                          [SVGLineElement class], @"line",
-                          [SVGPathElement class], @"path",
-                          [SVGPolygonElement class], @"polygon",
-                          [SVGPolylineElement class], @"polyline",
-                          [SVGRectElement class], @"rect",
-                          [SVGSwitchElement class], @"switch",
-                          [SVGTitleElement class], @"title",
-                          [SVGTextElement class], @"text",
-                          [TinySVGTextAreaElement class], @"textArea",
-						   nil];
-		}
-	}
-	return self;
+- (NSDictionary *)elementMap {
+    if (!_elementMap) {
+        _elementMap = [NSDictionary dictionaryWithObjectsAndKeys:
+                      [SVGSVGElement class], @"svg",
+                      [SVGCircleElement class], @"circle",
+                      [SVGDescriptionElement class], @"description",
+                      [SVGEllipseElement class], @"ellipse",
+                      [SVGGElement class], @"g",
+                      [SVGClipPathElement class], @"clipPath",
+                      [SVGImageElement class], @"image",
+                      [SVGLineElement class], @"line",
+                      [SVGPathElement class], @"path",
+                      [SVGPolygonElement class], @"polygon",
+                      [SVGPolylineElement class], @"polyline",
+                      [SVGRectElement class], @"rect",
+                      [SVGSwitchElement class], @"switch",
+                      [SVGTitleElement class], @"title",
+                      [SVGTextElement class], @"text",
+                      [TinySVGTextAreaElement class], @"textArea",
+                      nil];
+    }
+    return _elementMap;
 }
 
-
--(NSArray*) supportedNamespaces
+-(NSArray *)supportedNamespaces
 {
-	return [NSArray arrayWithObjects:
-			 @"http://www.w3.org/2000/svg",
-			nil];
+    if( _supportedNamespaces == nil )
+        _supportedNamespaces = @[@"http://www.w3.org/2000/svg"];
+    return _supportedNamespaces;
 }
 
 /** "tags supported" is exactly the set of all SVGElement subclasses that already exist */
 -(NSArray*) supportedTags
 {
-	return [NSMutableArray arrayWithArray:[elementMap allKeys]];
+    return [self.elementMap allKeys];
 }
 
 - (Node*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node*) parentNode
 {
 	if( [[self supportedNamespaces] containsObject:XMLNSURI] )
 	{
-		Class elementClass = [elementMap objectForKey:name];
+		Class elementClass = [self.elementMap objectForKey:name];
 		
 		if (!elementClass) {
 			elementClass = [SVGElement class];

--- a/Source/Parsers/Parser Extensions/SVGKParserStyles.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserStyles.m
@@ -11,25 +11,25 @@
 #import "CSSStyleSheet.h"
 #import "StyleSheetList+Mutable.h"
 
+@interface SVGKParserStyles ()
+@property (nonatomic) NSArray *supportedNamespaces;
+@property (nonatomic) NSArray *supportedTags;
+@end
+
 @implementation SVGKParserStyles
 
-
-static NSSet *_svgParserStylesSupportedNamespaces = nil;
--(NSSet *) supportedNamespaces
+-(NSArray *)supportedNamespaces
 {
-    if( _svgParserStylesSupportedNamespaces == nil )
-        _svgParserStylesSupportedNamespaces = [[NSSet alloc] initWithObjects:
-        @"http://www.w3.org/2000/svg",
-        nil];
-	return _svgParserStylesSupportedNamespaces;
+    if( _supportedNamespaces == nil )
+        _supportedNamespaces = @[@"http://www.w3.org/2000/svg"];
+    return _supportedNamespaces;
 }
 
-static NSSet *_svgParserStylesSupportedTags = nil;
--(NSSet *)supportedTags
+-(NSArray *)supportedTags
 {
-    if( _svgParserStylesSupportedTags == nil )
-        _svgParserStylesSupportedTags = [[NSSet alloc] initWithObjects:@"style", nil];
-    return _svgParserStylesSupportedTags;
+    if( _supportedTags == nil )
+        _supportedTags = @[@"style"];
+    return _supportedTags;
 }
 
 -(Node *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node *)parentNode
@@ -69,14 +69,6 @@ static NSSet *_svgParserStylesSupportedTags = nil;
 			[parseResult.parsedDocument.rootElement.styleSheets.internalArray addObject:parsedStylesheet];
 		}
 
-}
-
-
-+(void)trim
-{
-    _svgParserStylesSupportedTags = nil;
-    
-    _svgParserStylesSupportedNamespaces = nil;
 }
 
 @end


### PR DESCRIPTION
Also fix the protocol method implementation, which should return NSArray instead of NSSet

CC @adamgit 

See the issue herer: #551 #641
See the reason that cause this crash: https://github.com/SVGKit/SVGKit/issues/551#issuecomment-527986599