### PR TITLE
Make safe for extensions

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -3658,6 +3658,7 @@
 		825CDAC01BDA4BC0003C1C12 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -3701,6 +3702,7 @@
 		825CDAC11BDA4BC0003C1C12 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;


### PR DESCRIPTION
Setting the flag `APPLICATION_EXTENSION_API_ONLY=YES` makes the warning 'Linking against a dylib which is not safe for use in application extensions' disappear. 

Framework still builds and works correctly.