### PR TITLE
Using `pod_target_xcconfig` instead of `xcconfig` for custom build settings.

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.prefix_header_file = 'SVGKitLibrary/SVGKit-iOS/SVGKit-Prefix.pch'
   s.module_map = 'SVGKitLibrary/SVGKit-iOS/SVGKit.modulemap'
   s.requires_arc = true
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++11',
     'CLANG_CXX_LIBRARY' => 'libc++',
     'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'


### PR DESCRIPTION
Hello, there is an issue about setting singular target options in pods, it leads to warnings like `pod install` on 
```
[!] Can't merge user_target_xcconfig for pod targets: ["CNIOBoringSSL", "CNIOBoringSSLShims", "SVGKit"]. Singular build setting CLANG_CXX_LANGUAGE_STANDARD has different values.
```
I adjusted podspec according to recommendation from here
https://github.com/CocoaPods/CocoaPods/issues/3813#issuecomment-128445627
I tried on my project and it builds fine.
Please take a look.