### PR TITLE
Remove prefix header from `SVGKit.podspec`

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
   s.libraries = 'xml2'
   s.framework = 'QuartzCore', 'CoreText'
   s.dependency 'CocoaLumberjack', '~> 3.0'
-  s.prefix_header_file = 'SVGKitLibrary/SVGKit-iOS/SVGKit-Prefix.pch'
   s.module_map = 'SVGKitLibrary/SVGKit-iOS/SVGKit.modulemap'
   s.requires_arc = true
   s.pod_target_xcconfig = {


### PR DESCRIPTION
This fixes an issue that was caused by removing the prefix header without propagating the changes to `SVGKit.podspec`