### PR TITLE
Fix file exclusion that causes CocoaPods to fail to install

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -17,9 +17,7 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/SVGKit/SVGKit.git', :tag => s.version.to_s }
 
   s.source_files = 'Source/*.{h,m}', 'Source/**/*.{h,m}'
-  s.ios.exclude_files = 'Source/AppKit additions/*.{h,m}', 'Source/Exporters/SVGKExporterNSImage.{h,m}'
-  s.tvos.exclude_files = 'Source/AppKit additions/*.{h,m}', 'Source/Exporters/SVGKExporterNSImage.{h,m}'
-  s.osx.exclude_files = 'Source/Exporters/SVGKExporterUIImage.{h,m}'
+  s.exclude_files = 'Source/include/*.h'
   s.libraries = 'xml2'
   s.framework = 'QuartzCore', 'CoreText'
   s.dependency 'CocoaLumberjack', '~> 3.0'


### PR DESCRIPTION
@adamgit this should fix the issue of CocoaPods not found files.

It is possible to test changes in this PR with CocoaPods using:
```
pod 'SVGKit', :git => 'https://github.com/karimhm/SVGKit.git', :branch => 'pod_fix_test'
```

The issue is caused by adding platform checks guards such as:
https://github.com/SVGKit/SVGKit/blob/af9fa17df2ecb235a7f1f3966c610e4fb8404114/Source/Exporters/SVGKExporterNSImage.h#L9-L37

**CocoaPods seem to exclude files that contain nothing inside of them.**