### PR TITLE
Disambiguate Document.h import

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGDocument.h
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.h
@@ -15,7 +15,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Document.h"
+#import <SVGKit/Document.h>
 #import "SVGSVGElement.h"
 
 @interface SVGDocument : Document


### PR DESCRIPTION
Previously, if SVGKit and another library that exposed a "Document.h" header were both linked in the same project, this import could potentially resolve to the wrong one resulting in build errors. By disambiguating this, we can prevent conflicts with other libraries moving forward.