### PR TITLE
Revert "Disambiguate Document.h import"

### DIFF
--- a/SVGKit-iOS.xcodeproj/project.pbxproj
+++ b/SVGKit-iOS.xcodeproj/project.pbxproj
@@ -3668,6 +3668,7 @@
 				OTHER_CFLAGS = "-fembed-bitcode";
 				PRODUCT_NAME = "$(TARGET_NAME).${DYLIB_CURRENT_VERSION}";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Source";
 			};
 			name = Debug;
 		};
@@ -3691,6 +3692,7 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME).${DYLIB_CURRENT_VERSION}";
 				SKIP_INSTALL = YES;
+				USER_HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/Source";
 			};
 			name = Release;
 		};

--- a/Source/DOM classes/Core DOM/Document+Mutable.h
+++ b/Source/DOM classes/Core DOM/Document+Mutable.h
@@ -1,4 +1,4 @@
-#import "Document.h"
+#import "DOM classes/Core DOM/Document.h"
 
 @interface Document ()
 

--- a/Source/DOM classes/Core DOM/Document.m
+++ b/Source/DOM classes/Core DOM/Document.m
@@ -1,4 +1,4 @@
-#import "Document.h"
+#import "DOM classes/Core DOM/Document.h"
 #import "Document+Mutable.h"
 
 #import "DOMHelperUtilities.h"

--- a/Source/DOM classes/SVG-DOM/SVGDocument.h
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.h
@@ -15,7 +15,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Document.h"
+#import "DOM classes/Core DOM/Document.h"
 #import "SVGSVGElement.h"
 
 @interface SVGDocument : Document

--- a/Source/DOM classes/SVG-DOM/SVGDocument.h
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.h
@@ -15,7 +15,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <SVGKit/Document.h>
+#import "Document.h"
 #import "SVGSVGElement.h"
 
 @interface SVGDocument : Document

--- a/Source/SVGKit.h
+++ b/Source/SVGKit.h
@@ -52,7 +52,7 @@ FOUNDATION_EXPORT const unsigned char SVGKitFramework_VersionString[];
 #import "CSSValue_ForSubclasses.h"
 #import "CSSValue.h"
 #import "Document+Mutable.h"
-#import "Document.h"
+#import "DOM classes/Core DOM/Document.h"
 #import "DocumentCSS.h"
 #import "DocumentStyle.h"
 #import "StyleSheetList+Mutable.h"


### PR DESCRIPTION
Reverts SVGKit/SVGKit#690

This change breaks the build with an error like:
```
In file included from /Users/dtweston/src/SVGKit/Source/DOM classes/SVG-DOM/SVGTextPositioningElement.m:4:
In file included from /Users/dtweston/src/SVGKit/Source/DOM classes/Unported or Partial DOM/SVGElement_ForParser.h:3:
In file included from /Users/dtweston/src/SVGKit/Source/Parsers/SVGKParseResult.h:8:
/Users/dtweston/src/SVGKit/Source/DOM classes/SVG-DOM/SVGDocument.h:21:1: error: duplicate interface definition for class 'SVGDocument'
@interface SVGDocument : Document
^
In module 'SVGKit' imported from /Users/dtweston/src/SVGKit/Source/DOM classes/SVG-DOM/SVGDocument.h:18:
/Users/dtweston/src/SVGKit/Source/DOM classes/SVG-DOM/SVGDocument.h:21:12: note: previous definition is here
@interface SVGDocument : Document
           ^
```