### PR TITLE
Fix compilation issues on `3.x` branch

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "SVGKit",
     platforms: [
         .macOS(.v10_10),
-        .iOS(.v8),
+        .iOS(.v9),
         .tvOS(.v9)
     ],
     products: [

--- a/Source/DOM classes/SVG-DOM/SVGDocument.h
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.h
@@ -15,7 +15,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <SVGKit/Document.h>
+#import "Document.h"
 #import "SVGSVGElement.h"
 
 @interface SVGDocument : Document

--- a/Source/DOM classes/Unported or Partial DOM/SVGStyleCatcher.h
+++ b/Source/DOM classes/Unported or Partial DOM/SVGStyleCatcher.h
@@ -9,6 +9,10 @@
 #ifndef StyleTouch_SVGStyelCatcher_h
 #define StyleTouch_SVGStyelCatcher_h
 
+#if TARGET_OS_IOS 
+#import <UIKit/UIKit.h>
+#endif
+
 @class SVGElement;
 
 @protocol SVGStyleCatcher <NSObject>
@@ -16,7 +20,9 @@
 //-(void)styleCatchElement:(SVGElement *)styledLayer forClass:(NSString *)colorIndex;
 //-(void)styleCatchNewStyle:(NSString *)className;
 -(void)styleCatchLayer:(CALayer *)styledLayer forClass:(NSString *)colorIndex;
+#if TARGET_OS_IOS 
 -(UIColor *)styleCatchOverrideFill:(NSString *)fillClassName;
+#endif
 @end
 
 

--- a/Source/include/SVGKFastImageView.h
+++ b/Source/include/SVGKFastImageView.h
@@ -1,1 +1,1 @@
-../UIKit additions/SVGKFastImageView.h
+../ImageViews/SVGKFastImageView.h

--- a/Source/include/SVGKImageView.h
+++ b/Source/include/SVGKImageView.h
@@ -1,1 +1,1 @@
-../UIKit additions/SVGKImageView.h
+../ImageViews/SVGKImageView.h

--- a/Source/include/SVGKLayeredImageView.h
+++ b/Source/include/SVGKLayeredImageView.h
@@ -1,1 +1,1 @@
-../UIKit additions/SVGKLayeredImageView.h
+../ImageViews/SVGKLayeredImageView.h


### PR DESCRIPTION
I imported SVGKit as SPM on my project and I found out some compilation issues. This PR fix them:

- Increase Package min version to 9.0 to be used on XCode 12
- Fix broken aliases (on `ImageViews` folder)
- Import UIKit library to define UIColor -> Maybe this breaks MACOS compilation, I am not sure. In any case, MACOS compilation is broken either since UIColor is not valid ¯\\\_(ツ)\_/¯. At least, iOS compilation works now.
- Import `Document.h` properly