### PR TITLE
Fixed a crash when loading some SVG images

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -677,7 +677,10 @@ static NSMutableDictionary* globalSVGKImageCache;
     /**
      Special handling for clip-path; need to create their children
      */
-    NSString* clipPath = [element cascadedValueForStylableProperty:@"clip-path" inherit:NO];
+    NSString* clipPath;
+    if ([element isKindOfClass:[SVGElement class]]) {
+        clipPath = [element cascadedValueForStylableProperty:@"clip-path" inherit:NO];
+    }
     if ( [clipPath hasPrefix:@"url"] )
     {
         NSRange idKeyRange = NSMakeRange(5, clipPath.length - 6);


### PR DESCRIPTION
For example, a crash occurs when loading this image：
https://raw.githubusercontent.com/Hxmic/cdn/master/badge.svg
