### PR TITLE
Fixes SVGLength.m assertion failure on Apple Silicon simulator

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -229,7 +229,7 @@ static float cachedDevicePixelsPerInch;
         return 326.0f;
     }
 	
-	if( [platform hasPrefix:@"x86_64"])
+	if( [platform hasPrefix:@"x86_64"] || [platform hasPrefix:@"arm64"])
 	{
 		SVGKitLogWarn(@"[%@] WARNING: you are running on the simulator; it's impossible for us to calculate centimeter/millimeter/inches units correctly", [self class]);
 		return 132.0f; // Simulator, running on desktop machine


### PR DESCRIPTION
Via #716, fixes `SVGLength.m` assertion failure on Apple Silicon M1 simulator by adding a match on prefix "arm64".