### PR TITLE
Update podspec to make unused header files private

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = 'SVGKit'
-  s.version     = '2.1.0'
+  s.version     = '3.1.0'
   s.license     = 'MIT'
   s.osx.deployment_target = '10.9'
   s.ios.deployment_target = '5.0'
@@ -15,9 +15,12 @@ Pod::Spec.new do |s|
                  'Matt Rajca'      => 'matt.rajca@me.com',
                  'Moritz Pfeiffer' => 'moritz.pfeiffer@alp-phone.ch' }
   s.source   = { :git => 'https://github.com/SVGKit/SVGKit.git', :tag => s.version.to_s }
-
   s.source_files = 'Source/*.{h,m}', 'Source/**/*.{h,m}'
   s.exclude_files = 'Source/include/*.h'
+  s.private_header_files = 'Source/SVGKDefine_Private.h'
+  s.ios.private_header_files = 'Source/AppKit additions/SVGKImageRep.h', 'Source/Exporters/SVGKExporterNSImage.h'
+  s.tvos.private_header_files = 'Source/AppKit additions/SVGKImageRep.h', 'Source/Exporters/SVGKExporterNSImage.h'
+  s.osx.private_header_files = 'Source/Exporters/SVGKExporterUIImage.h'
   s.libraries = 'xml2'
   s.framework = 'QuartzCore', 'CoreText'
   s.dependency 'CocoaLumberjack', '~> 3.0'


### PR DESCRIPTION
This PR addresses #687, #715

> Umbrella header for module 'SVGKit' does not include header 'SVGKDefine_Private.h'
Umbrella header for module 'SVGKit' does not include header 'SVGKImageRep.h'
Umbrella header for module 'SVGKit' does not include header 'SVGKExporterNSImage.h'

We are experiencing the same issue since the above three header files are public (Cocoapods default?) while not included in the umbrella header.
And our project treats warnings as errors.

Fix is to declare them as private headers in podspec if not included in `SVGKit.h`
