### PR TITLE
Copy transform for gradient

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGLinearGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGLinearGradientElement.m
@@ -129,8 +129,12 @@
             
             for (NSString* key in keys)
             {
-                if (![self hasAttribute:key] && [baseGradient hasAttribute:key])
+                if (![self hasAttribute:key] && [baseGradient hasAttribute:key]) {
                     [self setAttributeNS:svgNamespace qualifiedName:key value:[baseGradient getAttribute:key]];
+
+                    if (key == @"gradientTransform")
+                        self.transform = baseGradient.transform;
+                }
             }
             
         }


### PR DESCRIPTION
If one gradient has link on another we will copy all attributes in `- (void)synthesizeProperties`. But `transform` created from `gradientTransform` only in `- (void)postProcessAttributesAddingErrorsTo:(SVGKParseResult *)parseResult` and this method called before we copied attributes from `baseGradient`. 
So I just copy property `transform` from `baseGradient` if we copy `gradientTransform` attribute.

SVG to check it: 
```xml
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="829.6" height="1080" viewBox="0 0 829.5999755859375 1080" style="">
    <g>
        <defs>
            <linearGradient id="b" x1="-4920.23" y1="15935.5" x2="-4350.38" y2="15935.5" gradientTransform="rotate(180 -2111.75 8228.85)" gradientUnits="userSpaceOnUse">
                <stop offset="0" stop-color="#6c587b"></stop>
                <stop offset="1" stop-color="#5d649c"></stop>
            </linearGradient>
            <linearGradient id="a" x1="-4920.23" y1="15763.36" x2="-4350.38" y2="15763.36" gradientTransform="rotate(180 -2111.75 8228.85)" gradientUnits="userSpaceOnUse">
                <stop offset="0" stop-color="#ba79af"></stop>
                <stop offset="1" stop-color="#e19198"></stop>
            </linearGradient>
            <linearGradient id="e" x1="763.16" y1="817.55" x2="763.16" y2="229.28" xlink:href="#a"></linearGradient><linearGradient id="f" y1="883.35" x2="829.58" y2="883.35" xlink:href="#b"></linearGradient>
        </defs>
        <g data-name="Layer 2">
            <path fill="url(#e)" d="M829.6 229.3L696.7 357.7v329l132.9 130.9V229.3z"></path>
            <path fill="url(#f)" d="M696.7 686.7L411.8 851.2 126.9 686.7 0 810l414.8 270 414.8-262.4-132.9-130.9z"></path>
        </g>
    </g>
</svg>
```