### PR TITLE
fix: can not catch exception about array addObject function

### DIFF
--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -278,6 +278,10 @@
 
 -(Node*) appendChild:(Node*) newChild
 {
+    if (!newChild) {
+        [NSException raise:@"newChild is null" format:@"object cannot be nil"];
+    }
+    
 	[self.childNodes.internalArray removeObject:newChild]; // required by spec
 	[self.childNodes.internalArray addObject:newChild];
 	

--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -478,6 +478,8 @@ static void processingInstructionSAX (void * ctx,
 			
 			/** Parser Extenstion creates a node for us */
 			Node* subParserResult = [subParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
+            NSAssert( subParserResult != nil, @"Found a tag (prefix:%@ name:%@) that is failing to return a valid node", prefix, name );
+            
 			
 #if DEBUG_XML_PARSER
 			SVGKitLogVerbose(@"[%@] tag: <%@:%@> id=%@ -- handled by subParser: %@", [self class], prefix, name, ([((Attr*)[attributeObjects objectForKey:@"id"]) value] != nil?[((Attr*)[attributeObjects objectForKey:@"id"]) value]:@"(none)"), subParser );
@@ -516,6 +518,7 @@ static void processingInstructionSAX (void * ctx,
 	
 	/** Parser Extenstion creates a node for us */
 	Node* subParserResult = [eventualParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
+    NSAssert( subParserResult != nil, @"Found a tag (prefix:%@ name:%@) that is failing to return a valid node", prefix, name );
 	
 #if DEBUG_XML_PARSER
 	SVGKitLogVerbose(@"[%@] tag: <%@:%@> id=%@ -- handled by subParser: %@", [self class], prefix, name, ([((Attr*)[attributeObjects objectForKey:@"id"]) value] != nil?[((Attr*)[attributeObjects objectForKey:@"id"]) value]:@"(none)"), eventualParser );


### PR DESCRIPTION
Array addObject function's exception can not be catched.
when the newChild is nil, will crash at `[self.childNodes.internalArray addObject:newChild];`.
So add a exception for `@catch`.

test url: https://upload.wikimedia.org/wikipedia/de/a/a3/Stoke_City.svg

```
@try
{
libXmlParserParseError = xmlParseChunk(ctx, buff, (int)bytesRead, 0);
}
@catch( NSException* e )
{
    SVGKitLogError( @"Exception while trying to parse SVG file, will store in parse results. Exception = %@", e);
    [currentParseRun addParseErrorFatal:[NSError errorWithDomain:@"SVGK Parsing" code:32523432 userInfo:@{NSLocalizedDescriptionKey:[NSString stringWithFormat:@"Exception = %@", e]}]];
}
```