### PR TITLE
Exclude headers in module map that are not included in umbrella header

### DIFF
--- a/SVGKitLibrary/SVGKit-iOS/SVGKit.modulemap
+++ b/SVGKitLibrary/SVGKit-iOS/SVGKit.modulemap
@@ -1,6 +1,10 @@
 framework module SVGKit {
   umbrella header "SVGKit.h"
 
+  exclude header "SVGKDefine_Private.h"
+  exclude header "SVGKExporterNSImage.h"
+  exclude header "SVGKImageRep.h"
+
   export *
   module * { export * }
 }


### PR DESCRIPTION
Header files not included in the umbrella header must be explicitly excluded
in the module map to avoid build warnings.

Add header excludes to eliminate the following build warnings:

Umbrella header for module 'SVGKit' does not include header 'SVGKDefine_Private.h'
Umbrella header for module 'SVGKit' does not include header 'SVGKExporterNSImage.h'
Umbrella header for module 'SVGKit' does not include header 'SVGKImageRep.h'

This allows projects that depend on the SVGKit pod to treat warnings as errors
without interference.