### PR TITLE
Elliptical arc flag arguments might not be separated by whitespace

### DIFF
--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -314,6 +314,23 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
     return p;
 }
 
+/**
+ flag  (An elliptical arc argument may present 2 flags as 00)
+ ("0"|"1")
+ */
+
++ (BOOL) readFlag:(NSScanner*)scanner
+{
+    if ([scanner scanString:@"0" intoString:NULL]) {
+        return FALSE;
+    }
+    if ([scanner scanString:@"1" intoString:NULL]) {
+        return TRUE;
+    }
+    NSAssert(FALSE, @"invalid flag value");
+    return FALSE;
+}
+
 + (void) readCoordinate:(NSScanner*)scanner intoFloat:(CGFloat*) floatPointer
 {
 #if CGFLOAT_IS_DOUBLE
@@ -831,11 +848,12 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
 	phi = fmod(phi, 2 * M_PI);
     
     [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
-	
-	CGPoint flags = [SVGKPointsAndPathsParser readCoordinatePair:scanner];
-	
-	BOOL largeArcFlag = flags.x != 0.;
-	BOOL sweepFlag = flags.y != 0.;
+
+    BOOL largeArcFlag = [SVGKPointsAndPathsParser readFlag:scanner];
+
+    [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
+
+    BOOL sweepFlag = [SVGKPointsAndPathsParser readFlag:scanner];
     
     [SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
     


### PR DESCRIPTION
Per [Section 9.3.9 of the SVG Spec](https://www.w3.org/TR/SVG/paths.html#PathDataBNF), the comma/whitespace between flags of an `elliptical_arc_argument` are optional `comma_wsp?` and the flags themselves are defined as single characters `flag::=("0"|"1")`, which means you might run into two flags represented as 00 or 01.  The current parsing implementation uses scanDouble and will treat two flags without whitespace as a single flag... leading to parsing errors further down the line.

An easy way to test this is to remove the whitespace from all flags in the first arc of the `heart.svg` file in your sample app.

`a15.39 15.39 0 00-22.59 2.34 1 1 0 01-1.59 0 15.14 15.14 0 00-22.38-2.2`

All other svg images in the sample app seem to display correctly with my changes except Reniel_compass_rose.svg which appears to have issues even without my changes.