### PR TITLE
Fix version of CocoaLumber

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.7.0"))
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.8.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
got error : the package product 'CocoaLumberjack' requires minimum platform version 9.0 for the iOS platform, but this target supports 9.0.   bump version of CocoaLumber. they released new version: https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.0