### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.8.0"))
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.7.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Change version for CocoaLumberjack.
If CocoaLumberjack have version upper 3.8.0, SVGKit build fails with error "The package product 'CocoaLumberjack' requires minimum platform version 11.0 for the iOS platform, but this target supports 9.0"