### PR TITLE
CocoaLumberjack Import Issue Fix

### DIFF
--- a/Source/SVGKDefine_Private.h
+++ b/Source/SVGKDefine_Private.h
@@ -8,7 +8,7 @@ SVGKDefine define some common macro used for private header.
 #define SVGKDefine_Private_h
 
 #import "SVGKDefine.h"
-#import <CocoaLumberjack/CocoaLumberjack.h>
+@import CocoaLumberjack;
 
 // These macro is only used inside framework project, does not expose to public header and effect user's define
 


### PR DESCRIPTION
As described in issue #775 there was an issue making new builds with SVGKit on the `3.x` branch because of an error importing `CocoaLumberjack` via a pre-compiler import. After doing some testing, it looks like switching to using an explicit module import resolves the issue.