### PR TITLE
Fixed a crash, a gradient render issue and an parsing assert

### DIFF
--- a/Demo-OSX.xcodeproj/project.pbxproj
+++ b/Demo-OSX.xcodeproj/project.pbxproj
@@ -87,6 +87,9 @@
 		55D8EE3B17628A71009C25F1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 55D8EE3A17628A71009C25F1 /* AppDelegate.m */; };
 		55D8EE3E17628A71009C25F1 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 55D8EE3C17628A71009C25F1 /* MainMenu.xib */; };
 		55D8EE4F17628FBC009C25F1 /* DemoSVGObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 55D8EE4E17628FBC009C25F1 /* DemoSVGObject.m */; };
+		D3FD0CDB2A0A7DED0028E15E /* Hoehenpunkte be CW.svg in Resources */ = {isa = PBXBuildFile; fileRef = D3FD0CD92A0A7DED0028E15E /* Hoehenpunkte be CW.svg */; };
+		D3FD0CEA2A0A87680028E15E /* Link2R_Mac.svg in Resources */ = {isa = PBXBuildFile; fileRef = D3FD0CE22A0A87680028E15E /* Link2R_Mac.svg */; };
+		D3FD0D062A0A8E190028E15E /* Attributes&-&GradientFill.svg in Resources */ = {isa = PBXBuildFile; fileRef = D3FD0D042A0A8E180028E15E /* Attributes&-&GradientFill.svg */; };
 		E0060539218BEBF300FC58FE /* shapes2.svg in Resources */ = {isa = PBXBuildFile; fileRef = E0060531218BEBF300FC58FE /* shapes2.svg */; };
 /* End PBXBuildFile section */
 
@@ -371,6 +374,9 @@
 		55D8EE3D17628A71009C25F1 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		55D8EE4D17628FBC009C25F1 /* DemoSVGObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DemoSVGObject.h; sourceTree = "<group>"; };
 		55D8EE4E17628FBC009C25F1 /* DemoSVGObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DemoSVGObject.m; sourceTree = "<group>"; };
+		D3FD0CD92A0A7DED0028E15E /* Hoehenpunkte be CW.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Hoehenpunkte be CW.svg"; sourceTree = "<group>"; };
+		D3FD0CE22A0A87680028E15E /* Link2R_Mac.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Link2R_Mac.svg; sourceTree = "<group>"; };
+		D3FD0D042A0A8E180028E15E /* Attributes&-&GradientFill.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "Attributes&-&GradientFill.svg"; sourceTree = "<group>"; };
 		E0060531218BEBF300FC58FE /* shapes2.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = shapes2.svg; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -392,6 +398,9 @@
 		32C4FCF42173976B00FBEDBF /* SVG */ = {
 			isa = PBXGroup;
 			children = (
+				D3FD0D042A0A8E180028E15E /* Attributes&-&GradientFill.svg */,
+				D3FD0CE22A0A87680028E15E /* Link2R_Mac.svg */,
+				D3FD0CD92A0A7DED0028E15E /* Hoehenpunkte be CW.svg */,
 				323C2E28218437C600741D80 /* Mozilla_Firefox_logo_2013.svg */,
 				32C4FCF52173976C00FBEDBF /* radialGradientTest.svg */,
 				32C4FCF62173976C00FBEDBF /* g-element-applies-rotation.svg */,
@@ -840,6 +849,7 @@
 				32C4FD6B2173976C00FBEDBF /* Snowman.png in Resources */,
 				32C4FD752173976C00FBEDBF /* gradients.svg in Resources */,
 				32C4FD642173976C00FBEDBF /* StyleAttribute.svg in Resources */,
+				D3FD0CEA2A0A87680028E15E /* Link2R_Mac.svg in Resources */,
 				32C4FD672173976C00FBEDBF /* svg-with-explicit-width-large.svg in Resources */,
 				32C4FD5B2173976C00FBEDBF /* arcs01.svg in Resources */,
 				32C4FD732173976C00FBEDBF /* transformations.svg in Resources */,
@@ -873,6 +883,7 @@
 				32C4FD692173976C00FBEDBF /* uk-only.svg in Resources */,
 				32C4FD432173976C00FBEDBF /* Lion.svg in Resources */,
 				32C4FD7C2173976C00FBEDBF /* heart.svg in Resources */,
+				D3FD0CDB2A0A7DED0028E15E /* Hoehenpunkte be CW.svg in Resources */,
 				32C4FD5A2173976C00FBEDBF /* fillrule-evenodd.svg in Resources */,
 				55D8EE3E17628A71009C25F1 /* MainMenu.xib in Resources */,
 				32C4FD612173976C00FBEDBF /* quad01.svg in Resources */,
@@ -891,6 +902,7 @@
 				32C4FD3C2173976C00FBEDBF /* Blank_Map-Africa.svg in Resources */,
 				32C4FD3E2173976C00FBEDBF /* imageWithASinglePointPath.svg in Resources */,
 				32C4FD722173976C00FBEDBF /* shapes.svg in Resources */,
+				D3FD0D062A0A8E190028E15E /* Attributes&-&GradientFill.svg in Resources */,
 				32C4FD792173976C00FBEDBF /* BlankMap-World6-Equirectangular.svg in Resources */,
 				32C4FD6E2173976C00FBEDBF /* Cycling_Lambie.svg in Resources */,
 				32C4FD762173976C00FBEDBF /* svg-with-explicit-width.svg in Resources */,

--- a/Demo-Samples/SVG/Attributes&-&GradientFill.svg
+++ b/Demo-Samples/SVG/Attributes&-&GradientFill.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Icons_Light" data-name="Icons Light" xmlns="http://www.w3.org/2000/svg" width="26" height="20" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 26 20">
+  <defs>
+    <linearGradient id="linear-gradient" x1=".49" y1="10" x2="13.49" y2="10" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#000" stop-opacity="0"/>
+      <stop offset="1" stop-color="#000"/>
+    </linearGradient>
+  </defs>
+  <path d="M.96,16.5c-.26,0-.47-.21-.47-.47V3.97c0-.26,.21-.47,.47-.47H13.02c.26,0,.47,.21,.47,.47V15.83c0,.37-.3,.67-.67,.67H.96Z" fill="url(#linear-gradient)"/>
+  <path d="M12.99,4V15.83c0,.09-.07,.17-.17,.17l-11.83,.03-.03-12.03H12.99m.03-1H.96C.42,3,0,3.43,0,3.97v12.06c0,.53,.43,.97,.97,.97H12.82c.64,0,1.17-.52,1.17-1.17V3.97c0-.53-.43-.97-.97-.97h0Z" fill="#2e2e2e"/>
+</svg>

--- a/Demo-Samples/SVG/Hoehenpunkte be CW.svg
+++ b/Demo-Samples/SVG/Hoehenpunkte be CW.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="20" viewBox="0 0 26 20">
+  <g id="b" data-name="Icons_Light">
+    <polygon points="6.5 5.5 3.5 17.5 21.5 17.5 6.5 5.5" style="fill: none; stroke: #2e2e2e; stroke-linecap: round; stroke-linejoin: round;"/>
+  </g>
+  <g id="m" data-name="Icons_Dark">
+    <g>
+      <path d="m23,14h0m0,0l-2.5,5-2.5-5h5m0-1h-5c-.35,0-.67.18-.85.47-.18.29-.2.66-.04.97l2.5,5c.17.34.52.55.89.55s.73-.21.89-.55l2.47-4.95c.09-.15.13-.32.13-.5,0-.55-.45-1-1-1h0Zm0,2h0,0Z" style="fill: #2e2e2e;"/>
+      <polygon points="18.81 14.5 22.19 14.5 20.5 17.88 18.81 14.5" style="fill: #e8e8e8;"/>
+      <path d="m21.38,15l-.88,1.76-.88-1.76h1.76m1.62-1h0,0Zm0,0h-5l2.5,5,2.5-5h0Z" style="fill: #e8e8e8;"/>
+    </g>
+    <g>
+      <path d="m6,14h0m0,0l-2.5,5-2.5-5h5m0-1H1c-.35,0-.67.18-.85.47-.18.29-.2.66-.04.97l2.5,5c.17.34.52.55.89.55s.73-.21.89-.55l2.47-4.95c.09-.15.13-.32.13-.5,0-.55-.45-1-1-1h0Zm0,2h0,0Z" style="fill: #2e2e2e;"/>
+      <polygon points="1.81 14.5 5.19 14.5 3.5 17.88 1.81 14.5" style="fill: #e8e8e8;"/>
+      <path d="m4.38,15l-.88,1.76-.88-1.76h1.76m1.62-1h0,0Zm0,0H1l2.5,5,2.5-5h0Z" style="fill: #e8e8e8;"/>
+    </g>
+    <g>
+      <path d="m9,3h0m0,0l-2.5,5-2.5-5h5m0-1h-5c-.35,0-.67.18-.85.47-.18.29-.2.66-.04.97l2.5,5c.17.34.52.55.89.55s.73-.21.89-.55l2.47-4.95c.09-.15.13-.32.13-.5,0-.55-.45-1-1-1h0Zm0,2h0,0Z" style="fill: #2e2e2e;"/>
+      <polygon points="4.81 3.5 8.19 3.5 6.5 6.88 4.81 3.5" style="fill: #e8e8e8;"/>
+      <path d="m7.38,4l-.88,1.76-.88-1.76h1.76m1.62-1h0,0Zm0,0h-5l2.5,5,2.5-5h0Z" style="fill: #e8e8e8;"/>
+    </g>
+    <rect x="21.5" y="5.5" width="3" height="5" rx="1.5" ry="1.5" style="fill: none; stroke: #2e2e2e; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.03px;"/>
+    <rect x="15.5" y=".5" width="3" height="5" rx="1.5" ry="1.5" style="fill: none; stroke: #2e2e2e; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.03px;"/>
+    <line x1="23.2" y1="1.5" x2="16.8" y2="9.5" style="fill: none; stroke: #2e2e2e; stroke-linecap: round; stroke-linejoin: round; stroke-width: .76px;"/>
+    <line x1="23.4" y1="1.25" x2="16.6" y2="9.75" style="fill: none; stroke: #2e2e2e; stroke-linecap: round; stroke-linejoin: round;"/>
+  </g>
+</svg>

--- a/Demo-Samples/SVG/Link2R_Mac.svg
+++ b/Demo-Samples/SVG/Link2R_Mac.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Icons_Light" data-name="Icons Light" xmlns="http://www.w3.org/2000/svg" width="20" height="30" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 20 30">
+  <image width="20" height="30" transform="translate(0)" xlink:href="../../../../../../../../../../Applications/Vectorworks EN 2022/Vectorworks 2022.app/Contents/Resources/Vectorworks.vwr/Images/Standard Images/Link2R_Mac.png"/>
+</svg>

--- a/Source/DOM classes/SVG-DOM/SVGLength.h
+++ b/Source/DOM classes/SVG-DOM/SVGLength.h
@@ -67,9 +67,9 @@ typedef enum SVG_LENGTH_TYPE
 -(float) pixelsValueWithDimension:(float)dimension;
 
 /** to calculate relative gradient values pass in the appropriate viewport dimension (width, height)
- *  the different between this and `pixelsValueWithDimension` is that this one will treat number value which (0 <= value <= 1.0) as percent value and calculate the result. (used by gradient)
+ *  if `treatAsPercentage` is true, this one will treat the number value in 0 <= value <= 1.0 as a percent value and calculate the result. (used by gradient)
  */
--(float) pixelsValueWithGradientDimension:(float)dimension;
+-(float) pixelsValueWithGradientDimension:(float)dimension treatAsPercentage:(BOOL)treatAsPercentage;
 
 /** returns this SVGLength as if it had been converted to a raw number (USE pixelsValue instead, UNLESS you are dealing with something that you expect to be a percentage or
  similar non-pixel value), using [self convertToSpecifiedUnits:SVG_LENGTHTYPE_NUMBER]

--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -121,11 +121,11 @@ static float cachedDevicePixelsPerInch;
     return [self pixelsValue];
 }
 
--(float) pixelsValueWithGradientDimension:(float)dimension
+-(float) pixelsValueWithGradientDimension:(float)dimension treatAsPercentage:(BOOL)treatAsPercentage
 {
     if (self.internalCSSPrimitiveValue.primitiveType == CSS_PERCENTAGE) {
         return dimension * self.value / 100.0;
-    } else if (self.internalCSSPrimitiveValue.primitiveType == CSS_NUMBER) {
+    } else if (treatAsPercentage && self.internalCSSPrimitiveValue.primitiveType == CSS_NUMBER) {
         if (self.value >= 0 && self.value <= 1) {
             return dimension * self.value;
         }

--- a/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGImageElement.m
@@ -112,7 +112,9 @@ CGImageRef SVGImageCGImage(UIImage *img)
 	/** Now we have some raw bytes, try to load using Apple's image loaders
 	 (will fail if the image is an SVG file)
 	 */
-	UIImage *image = [[UIImage alloc] initWithData:imageData];
+	UIImage *image;
+	if (imageData)
+		image = [[UIImage alloc] initWithData:imageData];
 	
     if( image == nil ) // NSData doesn't contain an imageformat Apple supports; might be an SVG instead
     {

--- a/Source/DOM classes/Unported or Partial DOM/SVGLinearGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGLinearGradientElement.m
@@ -44,10 +44,10 @@
     self.y2 = svgY2;
     
     // these should really be two separate code paths (objectBoundingBox and userSpaceOnUse), but we simplify the logic using `rectForRelativeUnits`
-    CGFloat x1 = [svgX1 pixelsValueWithGradientDimension:CGRectGetWidth(rectForRelativeUnits)];
-    CGFloat y1 = [svgY1 pixelsValueWithGradientDimension:CGRectGetHeight(rectForRelativeUnits)];
-    CGFloat x2 = [svgX2 pixelsValueWithGradientDimension:CGRectGetWidth(rectForRelativeUnits)];
-    CGFloat y2 = [svgY2 pixelsValueWithGradientDimension:CGRectGetHeight(rectForRelativeUnits)];
+	CGFloat x1 = [svgX1 pixelsValueWithGradientDimension:CGRectGetWidth(rectForRelativeUnits) treatAsPercentage:!inUserSpace];
+    CGFloat y1 = [svgY1 pixelsValueWithGradientDimension:CGRectGetHeight(rectForRelativeUnits) treatAsPercentage:!inUserSpace];
+    CGFloat x2 = [svgX2 pixelsValueWithGradientDimension:CGRectGetWidth(rectForRelativeUnits) treatAsPercentage:!inUserSpace];
+    CGFloat y2 = [svgY2 pixelsValueWithGradientDimension:CGRectGetHeight(rectForRelativeUnits) treatAsPercentage:!inUserSpace];
     CGPoint startPoint = CGPointMake(x1, y1);
     CGPoint endPoint = CGPointMake(x2, y2);
     

--- a/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGRadialGradientElement.m
@@ -63,13 +63,13 @@
     // these should really be two separate code paths (objectBoundingBox and userSpaceOnUse), but we simplify the logic using `rectForRelativeUnits`
     CGFloat width = CGRectGetWidth(rectForRelativeUnits);
     CGFloat height = CGRectGetHeight(rectForRelativeUnits);
-    CGFloat cx = [svgCX pixelsValueWithGradientDimension:width];
-    CGFloat cy = [svgCY pixelsValueWithGradientDimension:height];
+    CGFloat cx = [svgCX pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat cy = [svgCY pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
     CGFloat val = MIN(width, height);
-    CGFloat radius = [svgR pixelsValueWithGradientDimension:val];
+    CGFloat radius = [svgR pixelsValueWithGradientDimension:val treatAsPercentage:!inUserSpace];
     
-    CGFloat fx = [svgFX pixelsValueWithGradientDimension:width];
-    CGFloat fy = [svgFY pixelsValueWithGradientDimension:height];
+    CGFloat fx = [svgFX pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat fy = [svgFY pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
     
     CGPoint startPoint = CGPointMake(cx, cy);
     CGPoint endPoint = CGPointMake(fx, fy);

--- a/Source/Parsers/SVGKPointsAndPathsParser.m
+++ b/Source/Parsers/SVGKPointsAndPathsParser.m
@@ -1,5 +1,5 @@
 #import "SVGKPointsAndPathsParser.h"
-
+#import "SVGKDefine_Private.h"
 #import "NSCharacterSet+SVGKExtensions.h"
 
 
@@ -745,6 +745,8 @@ static inline CGPoint SVGCurveReflectedControlPoint(SVGCurve prevCurve)
     CGPathAddLineToPoint(path, NULL, coord.x, coord.y);
 
     while (![scanner isAtEnd]) {
+		[SVGKPointsAndPathsParser readCommaAndWhitespace:scanner];
+		
         origin = isRelative ? coord : origin;
         [SVGKPointsAndPathsParser readCoordinate:scanner intoFloat:&xValue];
         horizCoord = CGPointMake(origin.x+xValue, origin.y);

--- a/Source/QuartzCore additions/SVGGradientLayer.m
+++ b/Source/QuartzCore additions/SVGGradientLayer.m
@@ -70,10 +70,10 @@
     
     CGFloat width = CGRectGetWidth(rectForRelativeUnits);
     CGFloat height = CGRectGetHeight(rectForRelativeUnits);
-    CGFloat x1 = [gradientElement.x1 pixelsValueWithGradientDimension:width];
-    CGFloat y1 = [gradientElement.y1 pixelsValueWithGradientDimension:height];
-    CGFloat x2 = [gradientElement.x2 pixelsValueWithGradientDimension:width];
-    CGFloat y2 = [gradientElement.y2 pixelsValueWithGradientDimension:height];
+    CGFloat x1 = [gradientElement.x1 pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat y1 = [gradientElement.y1 pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
+    CGFloat x2 = [gradientElement.x2 pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat y2 = [gradientElement.y2 pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
     CGPoint gradientStartPoint = CGPointMake(x1, y1);
     CGPoint gradientEndPoint = CGPointMake(x2, y2);
     
@@ -126,16 +126,16 @@
     
     CGFloat width = CGRectGetWidth(rectForRelativeUnits);
     CGFloat height = CGRectGetHeight(rectForRelativeUnits);
-    CGFloat cx = [gradientElement.cx pixelsValueWithGradientDimension:width];
-    CGFloat cy = [gradientElement.cy pixelsValueWithGradientDimension:height];
+    CGFloat cx = [gradientElement.cx pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat cy = [gradientElement.cy pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
     CGPoint startPoint = CGPointMake(cx, cy);
     
     CGFloat val = MIN(width, height);
-    CGFloat radius = [gradientElement.r pixelsValueWithGradientDimension:val];
-    CGFloat focalRadius = [gradientElement.fr pixelsValueWithGradientDimension:val];
+    CGFloat radius = [gradientElement.r pixelsValueWithGradientDimension:val treatAsPercentage:!inUserSpace];
+    CGFloat focalRadius = [gradientElement.fr pixelsValueWithGradientDimension:val treatAsPercentage:!inUserSpace];
     
-    CGFloat fx = [gradientElement.fx pixelsValueWithGradientDimension:width];
-    CGFloat fy = [gradientElement.fy pixelsValueWithGradientDimension:height];
+    CGFloat fx = [gradientElement.fx pixelsValueWithGradientDimension:width treatAsPercentage:!inUserSpace];
+    CGFloat fy = [gradientElement.fy pixelsValueWithGradientDimension:height treatAsPercentage:!inUserSpace];
     
     CGPoint gradientEndPoint = CGPointMake(fx, fy);
     CGPoint gradientStartPoint = startPoint;


### PR DESCRIPTION
1. Link2R_Mac.svg has a reference to an inexistent file in it. It was crashing while loading.
2. Hoehenpunkte be CW.svg has a path with a "h0,0" command in it that wasn't being parsed properly and asserted.
3. Attributes&-&GradientFill.svg has a gradient that didn't render at all. The attributes were being parsed without accounting for the gradientUnits attribute.