### PR TITLE
Relax pinning of CocoaLumberjack

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.7.0"))
+        .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMajor(from: "3.7.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
I want to use this library in a project that has a dependency that requires CocoaLumberjack 3.8.0..<4.0.0, so I need to relax this version requirement. According to semver, anything under 4.0.0 should be a non-breaking change, so this should be fine.