### PR TITLE
#790 Xcode 14.3 Cocapods fix

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name        = 'SVGKit'
-  s.version     = '3.1.0'
+  s.version     = '3.1.1'
   s.license     = 'MIT'
-  s.osx.deployment_target = '10.9'
-  s.ios.deployment_target = '5.0'
-  s.tvos.deployment_target = '9.0'
+  s.osx.deployment_target = '11.0'
+  s.ios.deployment_target = '11.0'
+  s.tvos.deployment_target = '11.0'
   s.summary     = "Display and interact with SVG Images on iOS, using native rendering (CoreAnimation)."
   s.homepage = 'https://github.com/SVGKit/SVGKit'
   s.author   = { 'Steven Fusco'    => 'github@stevenfusco.com',


### PR DESCRIPTION
Dear team,

I hope you're all doing well. I wanted to let you know that I've successfully addressed the Xcode 14.3 issues related to cocoa pods by updating the spec deployment targets #790. Additionally, I've bumped the spec version.

To ensure everything is in order, I've already executed `pod lib lint` on Xcode 14.3 with Cocoapods version `1.12.1`.

Once this pull request is merged, kindly create a new tag - `3.1.1`. Afterward, it's essential to run `pod trunk push` from the tagged version.

This fix will be incredibly helpful for anyone whose cocoa pods library depends on SVGKit and has encountered linker errors on Xcode 14.3.

Thank you for your attention to this matter, and please feel free to reach out if you have any questions or concerns.

Best regards,
Artur