### PR TITLE
Log error instead of crashing - Fix Issue #793

### DIFF
--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -330,8 +330,12 @@ static NSMutableDictionary* globalSVGKImageCache;
 }
 
 - (id)initWithSource:(SVGKSource *)newSource {
-	NSAssert( newSource != nil, @"Attempted to init an SVGKImage using a nil SVGKSource");
-	
+    if( newSource == nil )
+    {
+        SVGKitLogError(@"Attempted to init an SVGKImage using a nil SVGKSource");
+        return nil;
+    }
+
 	self = [self initWithParsedSVG:[SVGKParser parseSourceUsingDefaultSVGKParser:newSource] fromSource:newSource];
 	
 	return self;


### PR DESCRIPTION
I've made it so it won't crash (Assert) when the source is nil. It will just log the error using SVGKit's internal error logger.

Reference filed issue for any details and follow-up dialog: https://github.com/SVGKit/SVGKit/issues/793

I've tested this and it's no longer crashing. To see the error, `SVGKit.enableLogging()`

I'm was getting a crash when trying this url: https://upload.wikimedia.org/wikipedia/commons/7/7c/Pistons_logo17.svg

`let svgImage = SVGKImage(contentsOf: svgUrl)`

Here's the crash log:
![Screenshot 2023-07-18 at 6 16 40 PM](https://github.com/SVGKit/SVGKit/assets/2114494/a81ed2a2-b736-45df-94c5-07d87073d4e1)

Here is the result when opening the URL in a web browser:

![Screenshot 2023-07-18 at 6 18 44 PM](https://github.com/SVGKit/SVGKit/assets/2114494/5e8d7d7f-41e3-4f60-9539-f9954780388b)

Here is the Xcode console upon crash:

```bash
libc++abi: terminating due to uncaught exception of type NSException
Message from debugger: Terminated due to signal 6
```

Error Log:

```bash
Error internally in Apple's NSData trying to read from URL 'https://upload.wikimedia.org/wikipedia/commons/7/7c/Pistons_logo17.svg'. Error = Error Domain=NSCocoaErrorDomain Code=256 "The file “Pistons_logo17.svg” couldn’t be opened." UserInfo={NSURL=https://upload.wikimedia.org/wikipedia/commons/7/7c/Pistons_logo17.svg}
```

Assertion:

```bash
Attempted to init an SVGKImage using a nil SVGKSource
```