### PR TITLE
Fix imports

### DIFF
--- a/Source/DOM classes/Core DOM/Attr.h
+++ b/Source/DOM classes/Core DOM/Attr.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import <Node.h>
 @class Element;
 
 @interface Attr : Node

--- a/Source/DOM classes/Core DOM/Attr.h
+++ b/Source/DOM classes/Core DOM/Attr.h
@@ -16,10 +16,10 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import <Node.h>
+#import "DomNode.h"
 @class Element;
 
-@interface Attr : Node
+@interface Attr : DomNode
 
 /*! NB: The official DOM spec FAILS TO SPECIFY what the value of "name" is */
 @property(nonatomic,strong,readonly) NSString* name;

--- a/Source/DOM classes/Core DOM/CharacterData.h
+++ b/Source/DOM classes/Core DOM/CharacterData.h
@@ -31,7 +31,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import <Node.h>
 
 @interface CharacterData : Node
 

--- a/Source/DOM classes/Core DOM/CharacterData.h
+++ b/Source/DOM classes/Core DOM/CharacterData.h
@@ -31,9 +31,9 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import <Node.h>
+#import "DomNode.h"
 
-@interface CharacterData : Node
+@interface CharacterData : DomNode
 
 @property(nonatomic,strong,readonly) NSString* data;
 	

--- a/Source/DOM classes/Core DOM/DOMHelperUtilities.h
+++ b/Source/DOM classes/Core DOM/DOMHelperUtilities.h
@@ -11,7 +11,7 @@
  */
 #import <Foundation/Foundation.h>
 
-@class Node, NodeList, Element; // avoiding #import here, to avoid C header loop problems.
+@class DomNode, NodeList, Element; // avoiding #import here, to avoid C header loop problems.
 
 #define DEBUG_DOM_MATCH_ELEMENTS_IDS_AND_NAMES 0 // For debugging SVGKit: causes debug output on getElementById etc
 
@@ -20,10 +20,10 @@
 /*! This useful method provides both the DOM level 1 and the DOM level 2 implementations of searching the tree for a node - because THEY ARE DIFFERENT
  yet very similar
  */
-+(void) privateGetElementsByName:(NSString*) name inNamespace:(NSString*) namespaceURI childrenOfElement:(Node*) parent addToList:(NodeList*) accumulator;
++(void) privateGetElementsByName:(NSString*) name inNamespace:(NSString*) namespaceURI childrenOfElement:(DomNode*) parent addToList:(NodeList*) accumulator;
 
 /*! This is used in multiple base classes in DOM 1 and DOM 2 where they do NOT have shared superclasses, so we have to implement it here in a separate
  clas as a standalone method */
-+(Element*) privateGetElementById:(NSString*) idValue childrenOfElement:(Node*) parent;
++(Element*) privateGetElementById:(NSString*) idValue childrenOfElement:(DomNode*) parent;
 
 @end

--- a/Source/DOM classes/Core DOM/DOMHelperUtilities.m
+++ b/Source/DOM classes/Core DOM/DOMHelperUtilities.m
@@ -10,7 +10,7 @@
 /*! This useful method provides both the DOM level 1 and the DOM level 2 implementations of searching the tree for a node - because THEY ARE DIFFERENT
  yet very similar
  */
-+(void) privateGetElementsByName:(NSString*) name inNamespace:(NSString*) namespaceURI childrenOfElement:(Node*) parent addToList:(NodeList*) accumulator
++(void) privateGetElementsByName:(NSString*) name inNamespace:(NSString*) namespaceURI childrenOfElement:(DomNode*) parent addToList:(NodeList*) accumulator
 {
 	/** According to spec, this is only valid for ELEMENT nodes */
 	if( [parent isKindOfClass:[Element class]] )
@@ -49,13 +49,13 @@
 		}
 	}
 	
-	for( Node* childNode in parent.childNodes )
+	for( DomNode* childNode in parent.childNodes )
 	{
 		[self privateGetElementsByName:name inNamespace:namespaceURI childrenOfElement:childNode addToList:accumulator];
 	}
 }
 
-+(Element*) privateGetElementById:(NSString*) idValue childrenOfElement:(Node*) parent
++(Element*) privateGetElementById:(NSString*) idValue childrenOfElement:(DomNode*) parent
 {
 	/** According to spec, this is only valid for ELEMENT nodes */
 	if( [parent isKindOfClass:[Element class]] )
@@ -73,7 +73,7 @@
 #endif
 	}
 	
-	for( Node* childNode in parent.childNodes )
+	for( DomNode* childNode in parent.childNodes )
 	{
 		Element* childResult = [self privateGetElementById:idValue childrenOfElement:childNode];
 		

--- a/Source/DOM classes/Core DOM/Document.h
+++ b/Source/DOM classes/Core DOM/Document.h
@@ -55,7 +55,7 @@
 #import <Foundation/Foundation.h>
 
 /** ObjectiveC won't allow this: @class Node; */
-#import <Node.h>
+#import "DomNode.h"
 @class Element;
 #import "Element.h"
 //@class Comment;
@@ -75,7 +75,7 @@
 @class AppleSucksDOMImplementation;
 #import "AppleSucksDOMImplementation.h"
 
-@interface Document : Node
+@interface Document : DomNode
 
 @property(nonatomic,strong,readonly) DocumentType*     doctype;
 @property(nonatomic,strong,readonly) AppleSucksDOMImplementation*  implementation;
@@ -94,7 +94,7 @@
 -(NodeList*) getElementsByTagName:(NSString*) data;
 
 // Introduced in DOM Level 2:
--(Node*) importNode:(Node*) importedNode deep:(BOOL) deep;
+-(DomNode*) importNode:(DomNode*) importedNode deep:(BOOL) deep;
 
 // Introduced in DOM Level 2:
 -(Element*) createElementNS:(NSString*) namespaceURI qualifiedName:(NSString*) qualifiedName __attribute__((ns_returns_retained));

--- a/Source/DOM classes/Core DOM/Document.h
+++ b/Source/DOM classes/Core DOM/Document.h
@@ -55,7 +55,7 @@
 #import <Foundation/Foundation.h>
 
 /** ObjectiveC won't allow this: @class Node; */
-#import "Node.h"
+#import <Node.h>
 @class Element;
 #import "Element.h"
 //@class Comment;

--- a/Source/DOM classes/Core DOM/Document.m
+++ b/Source/DOM classes/Core DOM/Document.m
@@ -69,7 +69,7 @@
 }
 
 // Introduced in DOM Level 2:
--(Node*) importNode:(Node*) importedNode deep:(BOOL) deep
+-(DomNode*) importNode:(DomNode*) importedNode deep:(BOOL) deep
 {
 	NSAssert( FALSE, @"Not implemented." );
 	return nil;

--- a/Source/DOM classes/Core DOM/DocumentFragment.h
+++ b/Source/DOM classes/Core DOM/DocumentFragment.h
@@ -10,8 +10,8 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import <Node.h>
+#import "DomNode.h"
 
-@interface DocumentFragment : Node
+@interface DocumentFragment : DomNode
 
 @end

--- a/Source/DOM classes/Core DOM/DocumentFragment.h
+++ b/Source/DOM classes/Core DOM/DocumentFragment.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import <Node.h>
 
 @interface DocumentFragment : Node
 

--- a/Source/DOM classes/Core DOM/DocumentType.h
+++ b/Source/DOM classes/Core DOM/DocumentType.h
@@ -17,7 +17,7 @@
 */
 #import <Foundation/Foundation.h>
 
-#import "Node.h"
+#import <Node.h>
 #import "NamedNodeMap.h"
 
 @interface DocumentType : Node

--- a/Source/DOM classes/Core DOM/DocumentType.h
+++ b/Source/DOM classes/Core DOM/DocumentType.h
@@ -17,10 +17,10 @@
 */
 #import <Foundation/Foundation.h>
 
-#import <Node.h>
+#import "DomNode.h"
 #import "NamedNodeMap.h"
 
-@interface DocumentType : Node
+@interface DocumentType : DomNode
 
 @property(nonatomic,strong,readonly) NSString* name;
 @property(nonatomic,strong,readonly) NamedNodeMap* entities;

--- a/Source/DOM classes/Core DOM/DomNode.h
+++ b/Source/DOM classes/Core DOM/DomNode.h
@@ -99,32 +99,32 @@ typedef enum DOMNodeType
 	DOMNodeType_NOTATION_NODE                  = 12
 } DOMNodeType;
 
-@interface Node : NSObject
+@interface DomNode : NSObject
 
 @property(nonatomic,strong,readonly) NSString* nodeName;
 @property(nonatomic,strong,readonly) NSString* nodeValue;
 	
 @property(nonatomic,readonly) DOMNodeType nodeType;
-@property(nonatomic,weak,readonly) Node* parentNode;
+@property(nonatomic,weak,readonly) DomNode* parentNode;
 @property(nonatomic,strong,readonly) NodeList* childNodes;
-@property(nonatomic,weak,readonly) Node* firstChild;
-@property(nonatomic,weak,readonly) Node* lastChild;
-@property(nonatomic,weak,readonly) Node* previousSibling;
-@property(nonatomic,weak,readonly) Node* nextSibling;
+@property(nonatomic,weak,readonly) DomNode* firstChild;
+@property(nonatomic,weak,readonly) DomNode* lastChild;
+@property(nonatomic,weak,readonly) DomNode* previousSibling;
+@property(nonatomic,weak,readonly) DomNode* nextSibling;
 @property(nonatomic,strong,readonly) NamedNodeMap* attributes; /**< NB: according to DOM Spec, this is null if the Node is NOT subclassed as an Element */
 
 // Modified in DOM Level 2:
 @property(nonatomic,weak,readonly) Document* ownerDocument;
 
--(Node*) insertBefore:(Node*) newChild refChild:(Node*) refChild;
+-(DomNode*) insertBefore:(DomNode*) newChild refChild:(DomNode*) refChild;
 
--(Node*) replaceChild:(Node*) newChild oldChild:(Node*) oldChild;
--(Node*) removeChild:(Node*) oldChild;
--(Node*) appendChild:(Node*) newChild;
+-(DomNode*) replaceChild:(DomNode*) newChild oldChild:(DomNode*) oldChild;
+-(DomNode*) removeChild:(DomNode*) oldChild;
+-(DomNode*) appendChild:(DomNode*) newChild;
 
 @property(nonatomic) BOOL hasChildNodes;
 
--(Node*) cloneNode:(BOOL) deep;
+-(DomNode*) cloneNode:(BOOL) deep;
 
 // Modified in DOM Level 2:
 -(void) normalize;

--- a/Source/DOM classes/Core DOM/DomNode.m
+++ b/Source/DOM classes/Core DOM/DomNode.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
 //
 
-#import <Node.h>
+#import "DomNode.h"
 #import "Node+Mutable.h"
 
 #import "NodeList+Mutable.h"
@@ -14,7 +14,7 @@
 
 #import "NamedNodeMap_Iterable.h" // Needed for the optional (non-SVG spec) "recursive toXML" method
 
-@implementation Node
+@implementation DomNode
 
 @synthesize nodeName;
 @synthesize nodeValue;
@@ -173,7 +173,7 @@
 
 #pragma mark - Official DOM method implementations
 
--(Node *)firstChild
+-(DomNode *)firstChild
 {
     if( [self.childNodes length] < 1 )
         return nil;
@@ -181,7 +181,7 @@
         return [self.childNodes item:0];
 }
 
--(Node *)lastChild
+-(DomNode *)lastChild
 {
     if( [self.childNodes length] < 1 )
         return nil;
@@ -189,7 +189,7 @@
         return [self.childNodes item: [self.childNodes length] - 1];
 }
 
--(Node *)previousSibling
+-(DomNode *)previousSibling
 {
     if( self.parentNode == nil )
         return nil;
@@ -204,7 +204,7 @@
     }
 }
 
--(Node *)nextSibling
+-(DomNode *)nextSibling
 {
     if( self.parentNode == nil )
         return nil;
@@ -219,7 +219,7 @@
     }
 }
 
--(Node*) insertBefore:(Node*) newChild refChild:(Node*) refChild
+-(DomNode*) insertBefore:(DomNode*) newChild refChild:(DomNode*) refChild
 {
 	if( refChild == nil )
 	{
@@ -234,7 +234,7 @@
 	return newChild;
 }
 
--(Node*) replaceChild:(Node*) newChild oldChild:(Node*) oldChild
+-(DomNode*) replaceChild:(DomNode*) newChild oldChild:(DomNode*) oldChild
 {
 	if( newChild.nodeType == DOMNodeType_DOCUMENT_FRAGMENT_NODE )
 	{
@@ -247,7 +247,7 @@
 		
 		NSAssert( FALSE, @"We should be recursing down the tree to find 'newChild' at any location, and removing it - required by spec - but we have no convenience method for that search, yet" );
 		
-		for( Node* child in newChild.childNodes.internalArray )
+		for( DomNode* child in newChild.childNodes.internalArray )
 		{
 			[self.childNodes.internalArray insertObject:child atIndex:oldIndex++];
 		}
@@ -267,7 +267,7 @@
 		return oldChild;
 	}
 }
--(Node*) removeChild:(Node*) oldChild
+-(DomNode*) removeChild:(DomNode*) oldChild
 {
 	[self.childNodes.internalArray removeObject:oldChild];
 	
@@ -276,7 +276,7 @@
 	return oldChild;
 }
 
--(Node*) appendChild:(Node*) newChild
+-(DomNode*) appendChild:(DomNode*) newChild
 {
 	[self.childNodes.internalArray removeObject:newChild]; // required by spec
 	[self.childNodes.internalArray addObject:newChild];
@@ -291,7 +291,7 @@
 	return (self.childNodes.length > 0);
 }
 
--(Node*) cloneNode:(BOOL) deep
+-(DomNode*) cloneNode:(BOOL) deep
 {
 	NSAssert( FALSE, @"Not implemented yet - read the spec. Sounds tricky. I'm too tired, and would probably screw it up right now" );
 	return nil;
@@ -347,7 +347,7 @@
 			 "concatenation of the textContent attribute value of every child node, excluding COMMENT_NODE and PROCESSING_INSTRUCTION_NODE nodes. This is the empty string if the node has no children."
 			 */
 			NSMutableString* stringAccumulator = [[NSMutableString alloc] init];
-			for( Node* subNode in self.childNodes.internalArray )
+			for( DomNode* subNode in self.childNodes.internalArray )
 			{
 				NSString* subText = subNode.textContent; // don't call this method twice; it's expensive to calculate!
 				if( subText != nil ) // Yes, really: Apple docs require that you never append a nil substring. Sigh
@@ -487,7 +487,7 @@
 	/** ... output them, making them 'active' in the output tree */
 	for( NSString* xmlnsNodeName in xmlnsNodemap )
 	{
-		Node* attribute = [xmlnsNodemap objectForKey:xmlnsNodeName];
+		DomNode* attribute = [xmlnsNodemap objectForKey:xmlnsNodeName];
 		
 		if( [prefixesByACTIVENamespace objectForKey:xmlnsNodeName] == nil )
 		{
@@ -534,7 +534,7 @@
 		NSDictionary* nodeMap = [nodeMapsByNamespace objectForKey:namespace];
 		for( NSString* nodeNameFromMap in nodeMap )
 		{
-			Node* attribute = [nodeMap objectForKey:nodeNameFromMap];
+			DomNode* attribute = [nodeMap objectForKey:nodeNameFromMap];
 			
 			attribute.prefix = localPrefix; /** Overrides any default pre-existing value */
 			
@@ -595,7 +595,7 @@
 		case DOMNodeType_DOCUMENT_NODE:
 		case DOMNodeType_ELEMENT_NODE:
 		{
-			for( Node* child in self.childNodes )
+			for( DomNode* child in self.childNodes )
 			{
 				[child appendXMLToString:outputString availableNamespaces:prefixesByKNOWNNamespace activeNamespaces:prefixesByACTIVENamespace];
 			}

--- a/Source/DOM classes/Core DOM/Element.h
+++ b/Source/DOM classes/Core DOM/Element.h
@@ -49,7 +49,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import <Node.h>
 @class Attr;
 #import "Attr.h"
 @class NodeList;

--- a/Source/DOM classes/Core DOM/Element.h
+++ b/Source/DOM classes/Core DOM/Element.h
@@ -49,13 +49,13 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import <Node.h>
+#import "DomNode.h"
 @class Attr;
 #import "Attr.h"
 @class NodeList;
 #import "NodeList.h"
 
-@interface Element : Node
+@interface Element : DomNode
 
 @property(nonatomic,strong,readonly) NSString* tagName;
 

--- a/Source/DOM classes/Core DOM/EntityReference.h
+++ b/Source/DOM classes/Core DOM/EntityReference.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node; */
-#import "Node.h"
+#import <Node.h>
 
 @interface EntityReference : Node
 

--- a/Source/DOM classes/Core DOM/EntityReference.h
+++ b/Source/DOM classes/Core DOM/EntityReference.h
@@ -9,8 +9,8 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node; */
-#import <Node.h>
+#import "DomNode.h"
 
-@interface EntityReference : Node
+@interface EntityReference : DomNode
 
 @end

--- a/Source/DOM classes/Core DOM/NamedNodeMap.h
+++ b/Source/DOM classes/Core DOM/NamedNodeMap.h
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 
 @class Node;
-#import "Node.h"
+#import <Node.h>
 
 @interface NamedNodeMap : NSObject </** needed so we can output SVG text in the [Node appendToXML:..] methods */ NSCopying>
 

--- a/Source/DOM classes/Core DOM/NamedNodeMap.h
+++ b/Source/DOM classes/Core DOM/NamedNodeMap.h
@@ -27,29 +27,29 @@
 
 #import <Foundation/Foundation.h>
 
-@class Node;
-#import <Node.h>
+@class DomNode;
+#import "DomNode.h"
 
 @interface NamedNodeMap : NSObject </** needed so we can output SVG text in the [Node appendToXML:..] methods */ NSCopying>
 
--(Node*) getNamedItem:(NSString*) name;
--(Node*) setNamedItem:(Node*) arg;
--(Node*) removeNamedItem:(NSString*) name;
--(Node*) item:(unsigned long) index;
+-(DomNode*) getNamedItem:(NSString*) name;
+-(DomNode*) setNamedItem:(DomNode*) arg;
+-(DomNode*) removeNamedItem:(NSString*) name;
+-(DomNode*) item:(unsigned long) index;
 
 @property(readonly) unsigned long length;
 
 // Introduced in DOM Level 2:
--(Node*) getNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName;
+-(DomNode*) getNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName;
 
 // Introduced in DOM Level 2:
--(Node*) setNamedItemNS:(Node*) arg;
+-(DomNode*) setNamedItemNS:(DomNode*) arg;
 
 // Introduced in DOM Level 2:
--(Node*) removeNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName;
+-(DomNode*) removeNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName;
 
 #pragma mark - MISSING METHOD FROM SVG Spec, without which you cannot parse documents (don't understand how they intended you to fulfil the spec without this method)
 
--(Node*) setNamedItemNS:(Node*) arg inNodeNamespace:(NSString*) nodesNamespace;
+-(DomNode*) setNamedItemNS:(DomNode*) arg inNodeNamespace:(NSString*) nodesNamespace;
 
 @end

--- a/Source/DOM classes/Core DOM/NamedNodeMap.m
+++ b/Source/DOM classes/Core DOM/NamedNodeMap.m
@@ -29,9 +29,9 @@
 }
 
 
--(Node*) getNamedItem:(NSString*) name
+-(DomNode*) getNamedItem:(NSString*) name
 {
-	Node* simpleResult = [self.internalDictionary objectForKey:name];
+	DomNode* simpleResult = [self.internalDictionary objectForKey:name];
 	
 	if( simpleResult == nil )
 	{
@@ -57,22 +57,22 @@
 	return simpleResult;
 }
 
--(Node*) setNamedItem:(Node*) arg
+-(DomNode*) setNamedItem:(DomNode*) arg
 {
 	NSAssert( [[self.internalDictionaryOfNamespaces allKeys] count] < 1, @"WARNING: you are using namespaced attributes in parallel with non-namespaced. According to the DOM Spec, this leads to UNDEFINED behaviour. This is insane - you do NOT want to be doing this! Crashing deliberately...." );
 	
-	Node* oldNode = [self.internalDictionary objectForKey:arg.localName];
+	DomNode* oldNode = [self.internalDictionary objectForKey:arg.localName];
 	
 	[self.internalDictionary setObject:arg forKey:arg.localName];
 	
 	return oldNode;
 }
 
--(Node*) removeNamedItem:(NSString*) name
+-(DomNode*) removeNamedItem:(NSString*) name
 {
 	NSAssert( [[self.internalDictionaryOfNamespaces allKeys] count] < 1, @"WARNING: you are using namespaced attributes in parallel with non-namespaced. According to the DOM Spec, this leads to UNDEFINED behaviour. This is insane - you do NOT want to be doing this! Crashing deliberately...." );
 	
-	Node* oldNode = [self.internalDictionary objectForKey:name];
+	DomNode* oldNode = [self.internalDictionary objectForKey:name];
 	
 	[self.internalDictionary removeObjectForKey:name];
 	
@@ -91,7 +91,7 @@
 	return count;
 }
 
--(Node*) item:(unsigned long) index
+-(DomNode*) item:(unsigned long) index
 {
 	NSAssert(FALSE, @"This method is broken; Apple does not consistently return ordered values in dictionary.allValues. Apple DOES NOT SUPPORT ordered Maps/Hashes/Tables/Hashtables - we have to re-implement this wheel from scratch");
 	
@@ -114,7 +114,7 @@
 }
 
 // Introduced in DOM Level 2:
--(Node*) getNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName
+-(DomNode*) getNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName
 {
 	NSMutableDictionary* namespaceDict = [self.internalDictionaryOfNamespaces objectForKey:namespaceURI];
 	
@@ -122,16 +122,16 @@
 }
 
 // Introduced in DOM Level 2:
--(Node*) setNamedItemNS:(Node*) arg
+-(DomNode*) setNamedItemNS:(DomNode*) arg
 {
 	return [self setNamedItemNS:arg inNodeNamespace:nil];
 }
 
 // Introduced in DOM Level 2:
--(Node*) removeNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName
+-(DomNode*) removeNamedItemNS:(NSString*) namespaceURI localName:(NSString*) localName
 {
 	NSMutableDictionary* namespaceDict = [self.internalDictionaryOfNamespaces objectForKey:namespaceURI];
-	Node* oldNode = [namespaceDict objectForKey:localName];
+	DomNode* oldNode = [namespaceDict objectForKey:localName];
 	
 	[namespaceDict removeObjectForKey:localName];
 	
@@ -140,7 +140,7 @@
 
 #pragma mark - MISSING METHOD FROM SVG Spec, without which you cannot parse documents (don't understand how they intended you to fulfil the spec without this method)
 
--(Node*) setNamedItemNS:(Node*) arg inNodeNamespace:(NSString*) nodesNamespace
+-(DomNode*) setNamedItemNS:(DomNode*) arg inNodeNamespace:(NSString*) nodesNamespace
 {
 	NSString* effectiveNamespace = arg.namespaceURI != nil ? arg.namespaceURI : nodesNamespace;
 	if( effectiveNamespace == nil )
@@ -154,7 +154,7 @@
 		namespaceDict = [NSMutableDictionary dictionary];
 		[self.internalDictionaryOfNamespaces setObject:namespaceDict forKey:effectiveNamespace];
 	}
-	Node* oldNode = [namespaceDict objectForKey:arg.localName];
+	DomNode* oldNode = [namespaceDict objectForKey:arg.localName];
 	
 	[namespaceDict setObject:arg forKey:arg.localName];
 	

--- a/Source/DOM classes/Core DOM/Node+Mutable.h
+++ b/Source/DOM classes/Core DOM/Node+Mutable.h
@@ -1,7 +1,7 @@
 /**
  Makes the writable properties all package-private, effectively
  */
-#import "Node.h"
+#import <Node.h>
 
 @interface Node()
 @property(nonatomic,strong,readwrite) NSString* nodeName;

--- a/Source/DOM classes/Core DOM/Node+Mutable.h
+++ b/Source/DOM classes/Core DOM/Node+Mutable.h
@@ -1,14 +1,14 @@
 /**
  Makes the writable properties all package-private, effectively
  */
-#import <Node.h>
+#import "DomNode.h"
 
-@interface Node()
+@interface DomNode()
 @property(nonatomic,strong,readwrite) NSString* nodeName;
 @property(nonatomic,strong,readwrite) NSString* nodeValue;
 
 @property(nonatomic,readwrite) DOMNodeType nodeType;
-@property(nonatomic,weak,readwrite) Node* parentNode;
+@property(nonatomic,weak,readwrite) DomNode* parentNode;
 @property(nonatomic,strong,readwrite) NodeList* childNodes;
 @property(nonatomic,strong,readwrite) NamedNodeMap* attributes;
 

--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
 //
 
-#import "Node.h"
+#import <Node.h>
 #import "Node+Mutable.h"
 
 #import "NodeList+Mutable.h"

--- a/Source/DOM classes/Core DOM/NodeList.h
+++ b/Source/DOM classes/Core DOM/NodeList.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 @class Node;
-#import "Node.h"
+#import <Node.h>
 
 @interface NodeList : NSObject <NSFastEnumeration>
 

--- a/Source/DOM classes/Core DOM/NodeList.h
+++ b/Source/DOM classes/Core DOM/NodeList.h
@@ -16,13 +16,13 @@
  */
 #import <Foundation/Foundation.h>
 
-@class Node;
-#import <Node.h>
+@class DomNode;
+#import "DomNode.h"
 
 @interface NodeList : NSObject <NSFastEnumeration>
 
 @property(readonly) NSUInteger length;
 
--(Node*) item:(NSUInteger) index;
+-(DomNode*) item:(NSUInteger) index;
 
 @end

--- a/Source/DOM classes/Core DOM/NodeList.m
+++ b/Source/DOM classes/Core DOM/NodeList.m
@@ -15,7 +15,7 @@
 }
 
 
--(Node*) item:(NSUInteger) index
+-(DomNode*) item:(NSUInteger) index
 {
 	return [self.internalArray objectAtIndex:index];
 }

--- a/Source/DOM classes/Core DOM/ProcessingInstruction.h
+++ b/Source/DOM classes/Core DOM/ProcessingInstruction.h
@@ -14,9 +14,9 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import <Node.h>
+#import "DomNode.h"
 
-@interface ProcessingInstruction : Node
+@interface ProcessingInstruction : DomNode
 @property(nonatomic,strong,readonly) NSString* target;
 @property(nonatomic,strong,readonly) NSString* data;
 

--- a/Source/DOM classes/Core DOM/ProcessingInstruction.h
+++ b/Source/DOM classes/Core DOM/ProcessingInstruction.h
@@ -14,7 +14,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import <Node.h>
 
 @interface ProcessingInstruction : Node
 @property(nonatomic,strong,readonly) NSString* target;

--- a/Source/DOM classes/Core DOM/StyleSheet.h
+++ b/Source/DOM classes/Core DOM/StyleSheet.h
@@ -13,14 +13,14 @@
 
 #import <Foundation/Foundation.h>
 
-@class Node;
+@class DomNode;
 @class MediaList;
 
 @interface StyleSheet : NSObject
 
 @property(nonatomic,strong) NSString* type;
 @property(nonatomic) BOOL disabled;
-@property(nonatomic,strong) Node* ownerNode;
+@property(nonatomic,strong) DomNode* ownerNode;
 @property(nonatomic,strong) StyleSheet* parentStyleSheet;
 @property(nonatomic,strong) NSString* href;
 @property(nonatomic,strong) NSString* title;

--- a/Source/DOM classes/SVG-DOM/SVGDocument.m
+++ b/Source/DOM classes/SVG-DOM/SVGDocument.m
@@ -79,7 +79,7 @@
 
 /** implementation of allPrefixesByNamespace - stores "namespace string" : "ARRAY of prefix strings"
  */
-+(void) accumulateNamespacesForNode:(Node*) node intoDictionary:(NSMutableDictionary*) output
++(void) accumulateNamespacesForNode:(DomNode*) node intoDictionary:(NSMutableDictionary*) output
 {
 	/**
 	 First, find all the attributes that declare a new Namespace at this point */
@@ -90,7 +90,7 @@
 	
 	for( NSString* xmlnsNodeName in xmlnsNodemap )
 	{
-		Node* namespaceDeclaration = [xmlnsNodemap objectForKey:xmlnsNodeName];
+		DomNode* namespaceDeclaration = [xmlnsNodemap objectForKey:xmlnsNodeName];
 		
 		NSMutableArray* prefixesForNamespace = [output objectForKey:namespaceDeclaration.nodeValue];
 		if( prefixesForNamespace == nil )
@@ -103,7 +103,7 @@
 			[prefixesForNamespace addObject:namespaceDeclaration.localName];
 	}
 	
-	for( Node* childNode in node.childNodes )
+	for( DomNode* childNode in node.childNodes )
 	{
 		[self accumulateNamespacesForNode:childNode intoDictionary:output];
 	}

--- a/Source/DOM classes/Unported or Partial DOM/SVGElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGElement.m
@@ -98,7 +98,7 @@
 
 /*! Override so that we can automatically set / unset the ownerSVGElement and viewportElement properties,
  as required by SVG Spec */
--(void)setParentNode:(Node *)newParent
+-(void)setParentNode:(DomNode *)newParent
 {
 	[super setParentNode:newParent];
 	
@@ -128,7 +128,7 @@
 		}
 		else
 		{
-			Node* currentAncestor = newParent;
+			DomNode* currentAncestor = newParent;
 			SVGElement*	firstAncestorThatIsAnyKindOfSVGElement = nil;
 			while( firstAncestorThatIsAnyKindOfSVGElement == nil
 				  && currentAncestor != nil ) // if we run out of tree! This would be an error (see below)
@@ -177,14 +177,14 @@
 
 - (void)setRootOfCurrentDocumentFragment:(SVGSVGElement *)root {
     _rootOfCurrentDocumentFragment = root;
-    for (Node *child in self.childNodes)
+    for (DomNode *child in self.childNodes)
         if ([child isKindOfClass:SVGElement.class])
             ((SVGElement *) child).rootOfCurrentDocumentFragment = root;
 }
 
 - (void)setViewportElement:(SVGElement *)viewport {
     _viewportElement = viewport;
-    for (Node *child in self.childNodes)
+    for (DomNode *child in self.childNodes)
         if ([child isKindOfClass:SVGElement.class])
             ((SVGElement *) child).viewportElement = viewport;
 }
@@ -638,7 +638,7 @@
         /** Finally: move up the tree until you find a <G> or <SVG> node, and ask it to provide the value
          */
         
-        Node* parentElement = self.parentNode;
+        DomNode* parentElement = self.parentNode;
         while( parentElement != nil
               && ! [parentElement isKindOfClass:[SVGGElement class]]
               && ! [parentElement isKindOfClass:[SVGSVGElement class]])

--- a/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
@@ -13,7 +13,7 @@
 #import "CALayerWithChildHitTest.h"
 
 #import "SVGElement_ForParser.h" // to resolve Xcode circular dependencies; in long term, parsing SHOULD NOT HAPPEN inside any class whose name starts "SVG" (because those are reserved classes for the SVG Spec)
-#import "Node.h"
+#import <Node.h>
 
 @implementation SVGGroupElement
 

--- a/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
@@ -13,7 +13,7 @@
 #import "CALayerWithChildHitTest.h"
 
 #import "SVGElement_ForParser.h" // to resolve Xcode circular dependencies; in long term, parsing SHOULD NOT HAPPEN inside any class whose name starts "SVG" (because those are reserved classes for the SVG Spec)
-#import <Node.h>
+#import "DomNode.h"
 
 @implementation SVGGroupElement
 

--- a/Source/Parsers/Parser Extensions/SVGKParserDOM.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDOM.m
@@ -20,7 +20,7 @@
 	return [NSMutableArray array];
 }
 
-- (Node*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributeObjects parseResult:(SVGKParseResult *)parseResult parentNode:(Node*) parentNode
+- (DomNode*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributeObjects parseResult:(SVGKParseResult *)parseResult parentNode:(DomNode*) parentNode
 {
 	if( [[self supportedNamespaces] count] == 0
 	|| [[self supportedNamespaces] containsObject:XMLNSURI] ) // unnecesary here, but allows safe updates to this parser's matching later
@@ -37,7 +37,7 @@
 	return nil;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	
 }

--- a/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
@@ -33,7 +33,7 @@
 	instance.correspondingElement = original;
 	instance.correspondingUseElement = outermostUseElement;
 	
-	for( Node* subNode in original.childNodes )
+	for( DomNode* subNode in original.childNodes )
 	{
 		if( [subNode isKindOfClass:[SVGElement class]])
 		{
@@ -48,7 +48,7 @@
 	return instance;
 }
 
-- (Node*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node*) parentNode
+- (DomNode*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(DomNode*) parentNode
 {
 	if( [[self supportedNamespaces] containsObject:XMLNSURI] )
 	{	
@@ -109,7 +109,7 @@
 	return nil;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	
 }

--- a/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
@@ -1,6 +1,6 @@
 #import "SVGKParserDefsAndUse.h"
 
-#import "Node.h"
+#import <Node.h>
 #import "SVGKSource.h"
 #import "SVGKParseResult.h"
 

--- a/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
@@ -1,6 +1,6 @@
 #import "SVGKParserDefsAndUse.h"
 
-#import <Node.h>
+#import "DomNode.h"
 #import "SVGKSource.h"
 #import "SVGKParseResult.h"
 

--- a/Source/Parsers/Parser Extensions/SVGKParserGradient.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserGradient.m
@@ -37,9 +37,9 @@
     return _supportedTags;
 }
 
--(Node *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node *)parentNode
+-(DomNode *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(DomNode *)parentNode
 {    
-    Node *returnObject = nil;
+    DomNode *returnObject = nil;
     
     if( [name isEqualToString:@"linearGradient"] )
     {
@@ -86,7 +86,7 @@
     return returnObject;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	
 }

--- a/Source/Parsers/Parser Extensions/SVGKParserPatternsAndGradients.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserPatternsAndGradients.m
@@ -38,7 +38,7 @@
 	return [NSMutableArray arrayWithObjects:@"pattern", nil];
 }
 
-- (Node*)handleStartElement:(NSString *)name document:(SVGKSource*) document namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult*) parseResult parentNode:(Node*) parentNode
+- (DomNode*)handleStartElement:(NSString *)name document:(SVGKSource*) document namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult*) parseResult parentNode:(DomNode*) parentNode
 {
 		
 	NSAssert( FALSE, @"Patterns are not supported by SVGKit yet - no-one has implemented them" );
@@ -46,7 +46,7 @@
 	return nil;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	
 }

--- a/Source/Parsers/Parser Extensions/SVGKParserSVG.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserSVG.m
@@ -67,7 +67,7 @@
     return [self.elementMap allKeys];
 }
 
-- (Node*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node*) parentNode
+- (DomNode*) handleStartElement:(NSString *)name document:(SVGKSource*) SVGKSource namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(DomNode*) parentNode
 {
 	if( [[self supportedNamespaces] containsObject:XMLNSURI] )
 	{
@@ -186,7 +186,7 @@
 	return nil;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	
 }

--- a/Source/Parsers/Parser Extensions/SVGKParserStyles.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserStyles.m
@@ -32,7 +32,7 @@
     return _supportedTags;
 }
 
--(Node *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(Node *)parentNode
+-(DomNode *)handleStartElement:(NSString *)name document:(SVGKSource *)document namePrefix:(NSString *)prefix namespaceURI:(NSString *)XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult *)parseResult parentNode:(DomNode *)parentNode
 {
 	if( [[self supportedNamespaces] containsObject:XMLNSURI] )
 	{
@@ -57,7 +57,7 @@
 		return nil;
 }
 
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult
 {
 	/** This is where the magic happens ... */
 		NSString* c = [newNode.textContent stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];

--- a/Source/Parsers/SVGKParser.h
+++ b/Source/Parsers/SVGKParser.h
@@ -57,7 +57,7 @@
 	NSMutableString *_storedChars;
 	//NSMutableArray *_elementStack;
 	NSMutableArray * _stackOfParserExtensions;
-	Node * _parentOfCurrentNode;
+	DomNode * _parentOfCurrentNode;
 }
 
 @property(nonatomic,strong,readonly) SVGKSource* source;

--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -477,7 +477,7 @@ static void processingInstructionSAX (void * ctx,
 			[_stackOfParserExtensions addObject:subParser];
 			
 			/** Parser Extenstion creates a node for us */
-			Node* subParserResult = [subParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
+			DomNode* subParserResult = [subParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
 			
 #if DEBUG_XML_PARSER
 			SVGKitLogVerbose(@"[%@] tag: <%@:%@> id=%@ -- handled by subParser: %@", [self class], prefix, name, ([((Attr*)[attributeObjects objectForKey:@"id"]) value] != nil?[((Attr*)[attributeObjects objectForKey:@"id"]) value]:@"(none)"), subParser );
@@ -515,7 +515,7 @@ static void processingInstructionSAX (void * ctx,
 	[_stackOfParserExtensions addObject:eventualParser];
 	
 	/** Parser Extenstion creates a node for us */
-	Node* subParserResult = [eventualParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
+	DomNode* subParserResult = [eventualParser handleStartElement:name document:source namePrefix:prefix namespaceURI:XMLNSURI attributes:attributeObjects parseResult:self.currentParseRun parentNode:_parentOfCurrentNode];
 	
 #if DEBUG_XML_PARSER
 	SVGKitLogVerbose(@"[%@] tag: <%@:%@> id=%@ -- handled by subParser: %@", [self class], prefix, name, ([((Attr*)[attributeObjects objectForKey:@"id"]) value] != nil?[((Attr*)[attributeObjects objectForKey:@"id"]) value]:@"(none)"), eventualParser );

--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -23,7 +23,7 @@
 
 #import "SVGDocument_Mutable.h" // so we can modify the SVGDocuments we're parsing
 
-#import <Node.h>
+#import "DomNode.h"
 
 #import "SVGKSourceString.h"
 #import "SVGKSourceURL.h"

--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -23,7 +23,7 @@
 
 #import "SVGDocument_Mutable.h" // so we can modify the SVGDocuments we're parsing
 
-#import "Node.h"
+#import <Node.h>
 
 #import "SVGKSourceString.h"
 #import "SVGKSourceURL.h"

--- a/Source/Parsers/SVGKParserExtension.h
+++ b/Source/Parsers/SVGKParserExtension.h
@@ -19,7 +19,7 @@
 @class SVGKParseResult;
 #import "SVGKParseResult.h"
 
-#import "Node.h"
+#import <Node.h>
 
 /*! Experimental: allow SVGKit parser-extensions to insert custom data into an SVGKParseResult */
 #define ENABLE_PARSER_EXTENSIONS_CUSTOM_DATA 0

--- a/Source/Parsers/SVGKParserExtension.h
+++ b/Source/Parsers/SVGKParserExtension.h
@@ -19,7 +19,7 @@
 @class SVGKParseResult;
 #import "SVGKParseResult.h"
 
-#import <Node.h>
+#import "DomNode.h"
 
 /*! Experimental: allow SVGKit parser-extensions to insert custom data into an SVGKParseResult */
 #define ENABLE_PARSER_EXTENSIONS_CUSTOM_DATA 0

--- a/Source/Parsers/SVGKParserExtension.h
+++ b/Source/Parsers/SVGKParserExtension.h
@@ -42,12 +42,12 @@
  Because SVG-DOM uses DOM, custom parsers can return any object they like - so long as its some kind of
  subclass of DOM's Node class
  */
-- (Node*)handleStartElement:(NSString *)name document:(SVGKSource*) document namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult*) parseResult parentNode:(Node*) parentNode;
+- (DomNode*)handleStartElement:(NSString *)name document:(SVGKSource*) document namePrefix:(NSString*)prefix namespaceURI:(NSString*) XMLNSURI attributes:(NSMutableDictionary *)attributes parseResult:(SVGKParseResult*) parseResult parentNode:(DomNode*) parentNode;
 
 /**
  Primarily used by the few nodes - <TEXT> and <TSPAN> - that need to post-process their text-content.
  In SVG, almost all data is stored in the attributes instead
  */
--(void)handleEndElement:(Node *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult;
+-(void)handleEndElement:(DomNode *)newNode document:(SVGKSource *)document parseResult:(SVGKParseResult *)parseResult;
 
 @end

--- a/Source/SVGKImage.m
+++ b/Source/SVGKImage.m
@@ -653,7 +653,7 @@ static NSMutableDictionary* globalSVGKImageCache;
 	//DEBUG: SVGKitLogVerbose(@"[%@] DEBUG: converted SVG element (class:%@) to CALayer (class:%@ frame:%@ pointer:%@) for id = %@", [self class], NSStringFromClass([element class]), NSStringFromClass([layer class]), NSStringFromCGRect( layer.frame ), layer, element.identifier);
 	
 	NodeList* childNodes = element.childNodes;
-	Node* saveParentNode = nil;
+	DomNode* saveParentNode = nil;
 	/**
 	 Special handling for <use> tags - they have to masquerade invisibly as the node they are referring to
 	 */

--- a/Source/SVGKit.h
+++ b/Source/SVGKit.h
@@ -67,7 +67,7 @@ FOUNDATION_EXPORT const unsigned char SVGKitFramework_VersionString[];
 #import "NamedNodeMap.h"
 #import "NamedNodeMap_Iterable.h"
 #import "Node+Mutable.h"
-#import "Node.h"
+#import "DomNode.h"
 #import "NodeList+Mutable.h"
 #import "NodeList.h"
 #import "ProcessingInstruction.h"

--- a/Source/privateHeaders/SVGKDefine_Private.h
+++ b/Source/privateHeaders/SVGKDefine_Private.h
@@ -8,7 +8,7 @@ SVGKDefine define some common macro used for private header.
 #define SVGKDefine_Private_h
 
 #import "SVGKDefine.h"
-@import CocoaLumberjack;
+#import <CocoaLumberjack/CocoaLumberjack.h>
 
 // These macro is only used inside framework project, does not expose to public header and effect user's define
 


### PR DESCRIPTION
We use SVGKit in a react-native project that comes with Yoga which brings its own Node.h that SVGKit tries to make use of then. This makes builds fail obviously. 😢  I also added[ another import fix for CocoaLumberjack](https://github.com/troZee/SVGKit/commit/495ead905959a44a386bf06a0525f4aeb3a59722) that @troZee did. :)

Would be great if this could get merged here so we can switch back to the official repo. 🚀  Thanks!