### PR TITLE
chore: Update `Node.h` path into SVGKit/Node.h to fix namespace conflict with React Native Yoga's Node header file

### DIFF
--- a/Source/DOM classes/Core DOM/Attr.h
+++ b/Source/DOM classes/Core DOM/Attr.h
@@ -16,7 +16,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import "SVGKit/Node.h"
 @class Element;
 
 @interface Attr : Node

--- a/Source/DOM classes/Core DOM/CharacterData.h
+++ b/Source/DOM classes/Core DOM/CharacterData.h
@@ -31,7 +31,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface CharacterData : Node
 

--- a/Source/DOM classes/Core DOM/Document.h
+++ b/Source/DOM classes/Core DOM/Document.h
@@ -55,7 +55,7 @@
 #import <Foundation/Foundation.h>
 
 /** ObjectiveC won't allow this: @class Node; */
-#import "Node.h"
+#import "SVGKit/Node.h"
 @class Element;
 #import "Element.h"
 //@class Comment;

--- a/Source/DOM classes/Core DOM/DocumentFragment.h
+++ b/Source/DOM classes/Core DOM/DocumentFragment.h
@@ -10,7 +10,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface DocumentFragment : Node
 

--- a/Source/DOM classes/Core DOM/DocumentType.h
+++ b/Source/DOM classes/Core DOM/DocumentType.h
@@ -17,7 +17,7 @@
 */
 #import <Foundation/Foundation.h>
 
-#import "Node.h"
+#import "SVGKit/Node.h"
 #import "NamedNodeMap.h"
 
 @interface DocumentType : Node

--- a/Source/DOM classes/Core DOM/Element.h
+++ b/Source/DOM classes/Core DOM/Element.h
@@ -49,7 +49,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import "SVGKit/Node.h"
 @class Attr;
 #import "Attr.h"
 @class NodeList;

--- a/Source/DOM classes/Core DOM/EntityReference.h
+++ b/Source/DOM classes/Core DOM/EntityReference.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node; */
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface EntityReference : Node
 

--- a/Source/DOM classes/Core DOM/NamedNodeMap.h
+++ b/Source/DOM classes/Core DOM/NamedNodeMap.h
@@ -28,7 +28,7 @@
 #import <Foundation/Foundation.h>
 
 @class Node;
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface NamedNodeMap : NSObject </** needed so we can output SVG text in the [Node appendToXML:..] methods */ NSCopying>
 

--- a/Source/DOM classes/Core DOM/Node+Mutable.h
+++ b/Source/DOM classes/Core DOM/Node+Mutable.h
@@ -1,7 +1,7 @@
 /**
  Makes the writable properties all package-private, effectively
  */
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface Node()
 @property(nonatomic,strong,readwrite) NSString* nodeName;

--- a/Source/DOM classes/Core DOM/Node.m
+++ b/Source/DOM classes/Core DOM/Node.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 __MyCompanyName__. All rights reserved.
 //
 
-#import "Node.h"
+#import "SVGKit/Node.h"
 #import "Node+Mutable.h"
 
 #import "NodeList+Mutable.h"

--- a/Source/DOM classes/Core DOM/NodeList.h
+++ b/Source/DOM classes/Core DOM/NodeList.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 @class Node;
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface NodeList : NSObject <NSFastEnumeration>
 

--- a/Source/DOM classes/Core DOM/ProcessingInstruction.h
+++ b/Source/DOM classes/Core DOM/ProcessingInstruction.h
@@ -14,7 +14,7 @@
 #import <Foundation/Foundation.h>
 
 /** objc won't allow this: @class Node;*/
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @interface ProcessingInstruction : Node
 @property(nonatomic,strong,readonly) NSString* target;

--- a/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGGroupElement.m
@@ -13,7 +13,7 @@
 #import "CALayerWithChildHitTest.h"
 
 #import "SVGElement_ForParser.h" // to resolve Xcode circular dependencies; in long term, parsing SHOULD NOT HAPPEN inside any class whose name starts "SVG" (because those are reserved classes for the SVG Spec)
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 @implementation SVGGroupElement
 

--- a/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
+++ b/Source/Parsers/Parser Extensions/SVGKParserDefsAndUse.m
@@ -1,6 +1,6 @@
 #import "SVGKParserDefsAndUse.h"
 
-#import "Node.h"
+#import "SVGKit/Node.h"
 #import "SVGKSource.h"
 #import "SVGKParseResult.h"
 

--- a/Source/Parsers/SVGKParser.m
+++ b/Source/Parsers/SVGKParser.m
@@ -23,7 +23,7 @@
 
 #import "SVGDocument_Mutable.h" // so we can modify the SVGDocuments we're parsing
 
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 #import "SVGKSourceString.h"
 #import "SVGKSourceURL.h"

--- a/Source/Parsers/SVGKParserExtension.h
+++ b/Source/Parsers/SVGKParserExtension.h
@@ -19,7 +19,7 @@
 @class SVGKParseResult;
 #import "SVGKParseResult.h"
 
-#import "Node.h"
+#import "SVGKit/Node.h"
 
 /*! Experimental: allow SVGKit parser-extensions to insert custom data into an SVGKParseResult */
 #define ENABLE_PARSER_EXTENSIONS_CUSTOM_DATA 0

--- a/Source/SVGKit.h
+++ b/Source/SVGKit.h
@@ -67,7 +67,7 @@ FOUNDATION_EXPORT const unsigned char SVGKitFramework_VersionString[];
 #import "NamedNodeMap.h"
 #import "NamedNodeMap_Iterable.h"
 #import "Node+Mutable.h"
-#import "Node.h"
+#import "SVGKit/Node.h"
 #import "NodeList+Mutable.h"
 #import "NodeList.h"
 #import "ProcessingInstruction.h"


### PR DESCRIPTION
Update `Node.h` path into SVGKit/Node.h to fix namespace conflict with React Native Yoga's Node header file