### PR TITLE
Detect Simulator using pragma. Fixes/improves Issue #834

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -594,11 +594,10 @@ static float cachedDevicePixelsPerInch;
         return 326.0f;
     }
     
-    if( [platform hasPrefix:@"x86_64"] || [platform hasPrefix:@"arm64"])
-    {
-        SVGKitLogWarn(@"[%@] WARNING: you are running on the simulator; it's impossible for us to calculate centimeter/millimeter/inches units correctly", [self class]);
-        return 132.0f; // Simulator, running on desktop machine
-    }
+    #if TARGET_IPHONE_SIMULATOR
+    SVGKitLogWarn(@"[%@] WARNING: you are running on the simulator; it's impossible for us to calculate centimeter/millimeter/inches units correctly", [self class]);
+    return 132.0f; // Simulator, running on desktop machine
+    #endif
 
     NSAssert(FALSE, @"Cannot determine the PPI values for current device; returning 0.0f - hopefully this will crash your code (you CANNOT run SVG's that use CM/IN/MM etc until you fix this)" );
     return 0.0f; // Bet you'll get a divide by zero here...


### PR DESCRIPTION
Use TARGET_IPHONE_SIMULATOR instead of checking for string prefix. 

Fixes/improves https://github.com/SVGKit/SVGKit/issues/834