### PR TITLE
Disable assertions when building in release config using SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,8 @@ let package = Package(
             resources: [.process("Resources/PrivacyInfo.xcprivacy")],
             publicHeadersPath: "include",
             cSettings: [
-                .headerSearchPath("privateHeaders")
+                .headerSearchPath("privateHeaders"),
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
             ]
         ),
         .target(


### PR DESCRIPTION
As discussed in #839, Xcode does not automatically disable assertions in release mode when integrating via Swift Package Manager. We must explicitly set this flag using the Package manifest file.

To confirm the fix, I created a dummy NSAssert that always triggered, and ran my app against this package in release mode. It no longer crashed once using this setting.