### PR TITLE
iPad mini 7 bugfix

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -465,7 +465,7 @@ static float cachedDevicePixelsPerInch;
         
         // iPad mini 7
         @"iPad15,6": @326,
-        @"iPad15,7": @362,
+        @"iPad15,7": @326,
 
         // iPad Pro 11-inch (M4)
         @"iPad16,3": @264,

--- a/Source/DOM classes/SVG-DOM/SVGLength.m
+++ b/Source/DOM classes/SVG-DOM/SVGLength.m
@@ -463,6 +463,10 @@ static float cachedDevicePixelsPerInch;
         @"iPad14,10": @264,
         @"iPad14,11": @264,
         
+        // iPad mini 7
+        @"iPad15,6": @326,
+        @"iPad15,7": @362,
+
         // iPad Pro 11-inch (M4)
         @"iPad16,3": @264,
         @"iPad16,4": @264,


### PR DESCRIPTION
Apps kept crashing on iPad mini 7 due to internal identifier missing in SVGLength.m file.