### PR TITLE
Fix trimming whitespace from `font-family` attribute

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -424,7 +424,7 @@
         // delete ""
         NSString *fontFamily = [arg stringByReplacingOccurrencesOfString:@"\"" withString:@""];
         // trim white space
-        [fontFamily stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+        fontFamily = [fontFamily stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
         [fontFamilies addObject:fontFamily];
     }
     


### PR DESCRIPTION
Font-family attributes like `font-family: one, two, three` were not correctly trimmed. It would try to pick fonts named ` one`, ` two` and ` three` instead of `one`, `two` then `three`.