### PR TITLE
fix: Null pointer from parsePaintColorForElement

### DIFF
--- a/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
+++ b/Source/DOM classes/SVG-DOM/SVGHelperUtilities.m
@@ -629,7 +629,7 @@
             }
         } else {
             if (![defaultColor isEqualToString:@"none"]) {
-                paintColorSVGColor = SVGColorFromString([actualPaintColor UTF8String]);
+                paintColorSVGColor = SVGColorFromString([defaultColor UTF8String]);
             } else {
                 return NULL;
             }


### PR DESCRIPTION
* Fixes https://github.com/SVGKit/SVGKit/issues/856