### PR TITLE
Font names and family names

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -326,6 +326,19 @@
                 break;
             }
         }
+
+        // some SVGs specify font name instead family name
+        if (!matchedFontFamily) {
+            // we didn't found font family, let's search the family based on the font name
+            for (NSString *familyName in availableFontFamilies) {
+                for (NSString *fontName in [UIFont fontNamesForFamilyName:familyName]) {
+                    if ([actualFontFamilies containsObject:fontName]) {
+                        matchedFontFamily = familyName;
+                        break;
+                    }
+                }
+            }
+        }
     }
     
     // we provide enough hint information, let Core Text using their algorithm to detect which fontName should be used


### PR DESCRIPTION
Some SVGs specify the font name (**SignText-Bold**) instead of the family (**Sign Text**). When this happens, SVGTextElement cannot find the family. I have added code to search for the family based on the font name.