### PR TITLE
Add missing macOS conditional to fix compilation (broken in #859 / a26fb84)

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -327,16 +327,30 @@
             }
         }
 
-        // some SVGs specify font name instead family name
+        // Some SVGs specify font name instead of family name
         if (!matchedFontFamily) {
-            // we didn't found font family, let's search the family based on the font name
+            // If we didn't find the font family, we'll search the family based on the font name
             for (NSString *familyName in availableFontFamilies) {
+                #if SVGKIT_MAC
+                NSArray<NSArray *> *members = [NSFontManager.sharedFontManager availableMembersOfFontFamily:familyName];
+                for (NSArray *member in members) {
+                    // Each member has the format: [fontName, weight, traits, size]
+                    if (member.count > 0) {
+                        NSString *fontName = member[0];
+                        if ([actualFontFamilies containsObject:fontName]) {
+                            matchedFontFamily = familyName;
+                            break;
+                        }
+                    }
+                }
+#else
                 for (NSString *fontName in [UIFont fontNamesForFamilyName:familyName]) {
                     if ([actualFontFamilies containsObject:fontName]) {
                         matchedFontFamily = familyName;
                         break;
                     }
                 }
+#endif
             }
         }
     }


### PR DESCRIPTION
SVGKit fails to compile on macOS following the changes made as part of pull request #859 / commit a26fb84.
This pull request adds the missing conditional branch for macOS to fix compilation.