### PR TITLE
fix: Initialize tileSize and translateSize to CGSizeZero

### DIFF
--- a/Source/ImageViews/SVGKFastImageView.m
+++ b/Source/ImageViews/SVGKFastImageView.m
@@ -225,8 +225,8 @@
 	
 	
 	CGSize scaleConvertImageToView;
-	CGSize tileSize;
-  CGSize translateSize;
+	CGSize tileSize = CGSizeZero;
+  CGSize translateSize = CGSizeZero;
 	if( cols == 1 && rows == 1 ) // if we are NOT tiling, then obey the UIViewContentMode as best we can!
 	{
 #ifdef USE_SUBLAYERS_INSTEAD_OF_BLIT


### PR DESCRIPTION
Without this, sometimes `tileSize` is initialized with a NaN value. This wont crash but`CGContextTranslateCTM` will fail, the image wont render and you'll a log :
```
Error: this application, or a library it uses, has passed an invalid numeric value (NaN, or not-a-number) to CoreGraphics API. This is a serious error and contributes to an overall degradation of system stability and reliability. This notice is a courtesy: please fix this problem. It will become a fatal error in an upcoming update
```
To debug this you have to add a breakpoint on `CGPostError` symbolic error. You can also add `CG_NUMERICS_SHOW_BACKTRACE` to sheme env variables to see the callstack