### PR TITLE
Added DEFINES_MODULE to podspec for React Native compatibility

### DIFF
--- a/SVGKit.podspec
+++ b/SVGKit.podspec
@@ -27,6 +27,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'CLANG_CXX_LANGUAGE_STANDARD' => 'gnu++11',
     'CLANG_CXX_LIBRARY' => 'libc++',
-    'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2'
+    'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2',
+    'DEFINES_MODULE' => 'YES'
   }
 end


### PR DESCRIPTION
## Summary
Adds `DEFINES_MODULE => 'YES'` to the podspec to enable proper module support for React Native projects.

## Problem
When using SVGKit in React Native projects, the pod fails to import as a module because it doesn't define `DEFINES_MODULE`. This forces users to add a workaround in their Podfile:
```ruby
pod 'SVGKit', :modular_headers => true
```

## Solution
This PR adds `'DEFINES_MODULE' => 'YES'` to the `pod_target_xcconfig` in the podspec, which:
- Enables proper module support out of the box
- Eliminates the need for the `:modular_headers => true` workaround

## Changes
- Added `'DEFINES_MODULE' => 'YES'` to `pod_target_xcconfig`

## Testing
Tested in a React Native project and confirmed SVGKit can now be imported without the Podfile workaround.