### PR TITLE
Update to build on visionOS

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -252,6 +252,8 @@
     
 #if SVGKIT_MAC
     label.contentsScale = [[NSScreen mainScreen] backingScaleFactor];
+#elif SVGKIT_VISION
+    label.contentsScale = 2.0;
 #else
     label.contentsScale = [[UIScreen mainScreen] scale];
 #endif

--- a/Source/Exporters/SVGKExporterUIImage.m
+++ b/Source/Exporters/SVGKExporterUIImage.m
@@ -23,8 +23,12 @@
         if (@available(iOS 10.0, *)) {
             UIGraphicsImageRendererFormat * rendererFormat = [[UIGraphicsImageRendererFormat alloc] init];
             rendererFormat.opaque = NO;
+#if SVGKIT_VISION
+            rendererFormat.scale = 2.0;
+#else
             rendererFormat.scale = [UIScreen mainScreen].scale;
-            
+#endif
+
             UIGraphicsImageRenderer * render = [[UIGraphicsImageRenderer alloc] initWithSize:image.size format:rendererFormat];
             
             UIImage* result = [render imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
@@ -35,15 +39,20 @@
             
             return result;
         } else {
-            UIGraphicsBeginImageContextWithOptions( image.size, FALSE, [UIScreen mainScreen].scale );
+#if SVGKIT_VISION
+            CGFloat scale = 2.0;
+#else
+            CGFloat scale = [UIScreen mainScreen].scale;
+#endif
+            UIGraphicsBeginImageContextWithOptions( image.size, FALSE, scale );
+
             CGContextRef context = UIGraphicsGetCurrentContext();
-            
+
             [image renderToContext:context antiAliased:shouldAntialias curveFlatnessFactor:multiplyFlatness interpolationQuality:interpolationQuality flipYaxis:FALSE];
-            
+
             UIImage* result = UIGraphicsGetImageFromCurrentImageContext();
             UIGraphicsEndImageContext();
-            
-            
+
             return result;
         }
 	}

--- a/Source/QuartzCore additions/CALayerWithClipRender.m
+++ b/Source/QuartzCore additions/CALayerWithClipRender.m
@@ -64,6 +64,8 @@
         CGFloat scale = MAX(layer.contentsScale, layer.mask.contentsScale);
 #if SVGKIT_MAC
         scale = MAX(scale, [[NSScreen mainScreen] backingScaleFactor]);
+#elif SVGKIT_VISION
+        scale = 2.0;
 #else
         scale = MAX(scale, [[UIScreen mainScreen] scale]);
 #endif

--- a/Source/SVGKDefine.h
+++ b/Source/SVGKDefine.h
@@ -13,7 +13,7 @@
 // Apple's defines from TargetConditionals.h are a bit weird.
 // Seems like TARGET_OS_MAC is always defined (on all platforms).
 // To determine if we are running on OSX, we can only rely on TARGET_OS_IPHONE=0 and all the other platforms
-#if !TARGET_OS_IPHONE && !TARGET_OS_IOS && !TARGET_OS_TV && !TARGET_OS_WATCH
+#if !TARGET_OS_IPHONE && !TARGET_OS_IOS && !TARGET_OS_TV && !TARGET_OS_WATCH && !TARGET_OS_VISION
 #define SVGKIT_MAC 1
 #else
 #define SVGKIT_MAC 0
@@ -21,7 +21,7 @@
 
 // iOS and tvOS are very similar, UIKit exists on both platforms
 // Note: watchOS also has UIKit, but it's very limited
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_VISION
 #define SVGKIT_UIKIT 1
 #else
 #define SVGKIT_UIKIT 0
@@ -37,6 +37,12 @@
 #define SVGKIT_TV 1
 #else
 #define SVGKIT_TV 0
+#endif
+
+#if TARGET_OS_VISION
+#define SVGKIT_VISION 1
+#else
+#define SVGKIT_VISION 0
 #endif
 
 #if TARGET_OS_WATCH


### PR DESCRIPTION
### Changes

Besides a couple usages of `[UIScreen mainScreen]`, `SVGKit` can build on visionOS
- On visionOS, scale will always be 2
- Add new `SVGKIT_VISION` ifdef