### PR TITLE
fix: add nullability annotations to suppress 25 Clang warnings

### DIFF
--- a/Source/Parsers/SVGKParseResult.h
+++ b/Source/Parsers/SVGKParseResult.h
@@ -12,6 +12,8 @@
 
 @class SVGElement;
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! Block type for custom identifier resolution
  * 
  * This block allows you to customize how identifiers are generated for SVGElement instances
@@ -46,8 +48,8 @@ typedef NSString *_Nullable (^SVGKParserIdentifierResolver)(SVGElement* element)
 /** 0.0 = no parsing done yet, 0.x = partially parsed, 1.0 = parse complete (no fatal errors) */
 @property(nonatomic) double parseProgressFractionApproximate;
 
-@property(nonatomic,strong) SVGSVGElement* rootOfSVGTree; /**< both are needed, see spec */
-@property(nonatomic,strong) SVGDocument* parsedDocument; /**< both are needed, see spec */
+@property(nonatomic,strong,nullable) SVGSVGElement* rootOfSVGTree; /**< both are needed, see spec */
+@property(nonatomic,strong,nullable) SVGDocument* parsedDocument; /**< both are needed, see spec */
 
 @property(nonatomic,strong) NSMutableDictionary* namespacesEncountered; /**< maps "prefix" to "uri" */
 
@@ -74,3 +76,5 @@ typedef NSString *_Nullable (^SVGKParserIdentifierResolver)(SVGElement* element)
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Parsers/SVGKParser.h
+++ b/Source/Parsers/SVGKParser.h
@@ -45,6 +45,8 @@
 
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! RECOMMENDED: leave this set to 1 to get warnings about "legal, but poorly written" SVG */
 #define PARSER_WARN_FOR_ANONYMOUS_SVG_G_TAGS 1
 
@@ -62,7 +64,7 @@
 
 @property(nonatomic,strong,readonly) SVGKSource* source;
 @property(nonatomic,strong,readonly) NSMutableArray* externalStylesheets;
-@property(nonatomic,strong,readonly) SVGKParseResult* currentParseRun;
+@property(nonatomic,strong,readonly,nullable) SVGKParseResult* currentParseRun;
 
 @property(nonatomic,strong) NSMutableArray* parserExtensions;
 @property(nonatomic,strong) NSMutableDictionary* parserKnownNamespaces; /**< maps "uri" to "array of parser-extensions" */
@@ -110,7 +112,7 @@
  
  Returns the fully-parsed result, including any errors
  */
-+ (SVGKParseResult*) parseSourceUsingDefaultSVGKParser:(SVGKSource*) source;
++ (nullable SVGKParseResult*) parseSourceUsingDefaultSVGKParser:(SVGKSource*) source;
 
 /**
  This MIGHT now be safe to call multiple times on different threads
@@ -118,9 +120,9 @@
  that break libxml in horrible ways, see the source code to this class
  for more info)
  */
-- (SVGKParseResult*) parseSynchronously;
+- (nullable SVGKParseResult*) parseSynchronously;
 
-+(NSDictionary *) NSDictionaryFromCSSAttributes: (Attr*) styleAttribute;
++(nullable NSDictionary *) NSDictionaryFromCSSAttributes: (Attr*) styleAttribute;
 
 
 
@@ -137,3 +139,5 @@
 
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Closes #873

## Summary
- Wraps `SVGKParseResult.h` and `SVGKParser.h` in `NS_ASSUME_NONNULL_BEGIN/END` so all pointer declarations are implicitly `_Nonnull`
- Explicitly marks `nullable` the six pointers that can legitimately be `nil`: `rootOfSVGTree`, `parsedDocument`, `currentParseRun`, `+parseSourceUsingDefaultSVGKParser:` return, `-parseSynchronously` return, and `+NSDictionaryFromCSSAttributes:` return
- Eliminates 25 "pointer is missing a nullability type specifier" Clang warnings when integrating SVGKit as a Swift Package

## Test plan
- [ ] Build the project as a Swift Package in Xcode and confirm the 25 warnings are gone from the Issue Navigator
- [ ] Verify existing unit tests continue to pass
- [ ] No functional changes — annotations are advisory only

🤖 Generated with [Claude Code](https://claude.com/claude-code)