### PR TITLE
fix(text): use single child tspan x/y when rendering text

### DIFF
--- a/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
+++ b/Source/DOM classes/Unported or Partial DOM/SVGTextElement.m
@@ -7,11 +7,37 @@
 #import "SVGUtils.h"
 #import "SVGTextLayer.h"
 #import "SVGKDefine_Private.h"
+#import "NodeList+Mutable.h"
 
 @implementation SVGTextElement
 
 @synthesize transform; // each SVGElement subclass that conforms to protocol "SVGTransformable" has to re-synthesize this to work around bugs in Apple's Objective-C 2.0 design that don't allow @properties to be extended by categories / protocols
 
+- (Node *)singleTspanChildForSimplePositioning
+{
+    Node *singleTspanChild = nil;
+    for (Node *childNode in self.childNodes.internalArray)
+    {
+        if (![childNode isKindOfClass:[Element class]])
+        {
+            continue;
+        }
+        
+        if (singleTspanChild != nil)
+        {
+            return nil;
+        }
+        
+        if (![childNode.localName isEqualToString:@"tspan"])
+        {
+            return nil;
+        }
+        
+        singleTspanChild = childNode;
+    }
+    
+    return singleTspanChild;
+}
 
 - (CALayer *) newLayer
 {
@@ -19,35 +45,64 @@
 	 BY DESIGN: we work out the positions of all text in ABSOLUTE space, and then construct the Apple CALayers and CATextLayers around
 	 them, as required.
 	 
-	 Because: Apple's classes REQUIRE us to provide a lot of this info up-front. Sigh
-	 And: SVGKit works by pre-baking everything into position (its faster, and avoids Apple's broken CALayer.transform property)
-	 */
-    if (self.x.valueAsString.length != 0 || self.y.valueAsString.length != 0)
+		 Because: Apple's classes REQUIRE us to provide a lot of this info up-front. Sigh
+		 And: SVGKit works by pre-baking everything into position (its faster, and avoids Apple's broken CALayer.transform property)
+		 */
+    SVGLength *resolvedX = self.x;
+    SVGLength *resolvedY = self.y;
+    NSString *resolvedTextContent = self.textContent;
+    NSString *resolvedXValue = self.x.valueAsString;
+    NSString *resolvedYValue = self.y.valueAsString;
+    Element *singleTspanChild = (Element *)[self singleTspanChildForSimplePositioning];
+    if (singleTspanChild != nil)
     {
-        // Simplify checks for x and y values being empty or not.
-        NSString *xValue = [self stringValueOrFormatted:self.x.valueAsString withValue:self.x.value];
-        NSString *yValue = [self stringValueOrFormatted:self.y.valueAsString withValue:self.y.value];
+        NSString *tspanXValue = [singleTspanChild getAttribute:@"x"];
+        NSString *tspanYValue = [singleTspanChild getAttribute:@"y"];
+        SVGLength *tspanX = [SVGLength svgLengthFromNSString:tspanXValue];
+        SVGLength *tspanY = [SVGLength svgLengthFromNSString:tspanYValue];
         
-        // Split the text based on the provided X and Y values.
-        NSArray<NSDictionary *> *splitItem = [self splitText:self.textContent basedOnX:xValue andY:yValue];
-        // If no split is needed, create a layer using the entire text content.
-        if (splitItem == nil) {
-            return [self newSubLayerWithX:self.x y:self.y textContent:self.textContent];
-        }
-        // If splitting is needed, create a parent layer and add sublayers for each text segment.
-        CALayer *layer = [CALayer new];
-        for (NSDictionary *item in splitItem)
+        if (tspanXValue.length != 0)
         {
+            resolvedX = tspanX;
+            resolvedXValue = tspanXValue;
+        }
+        if (tspanYValue.length != 0)
+        {
+            resolvedY = tspanY;
+            resolvedYValue = tspanYValue;
+        }
+        if (singleTspanChild.textContent.length > 0)
+        {
+            resolvedTextContent = singleTspanChild.textContent;
+        }
+    }
+    
+	    if (resolvedXValue.length != 0 || resolvedYValue.length != 0)
+	    {
+	        // Simplify checks for x and y values being empty or not.
+	        NSString *xValue = [self stringValueOrFormatted:resolvedXValue withValue:resolvedX.value];
+	        NSString *yValue = [self stringValueOrFormatted:resolvedYValue withValue:resolvedY.value];
+	        
+	        // Split the text based on the provided X and Y values.
+	        NSArray<NSDictionary *> *splitItem = [self splitText:resolvedTextContent basedOnX:xValue andY:yValue];
+	        // If no split is needed, create a layer using the entire text content.
+	        if (splitItem == nil) {
+	            return [self newSubLayerWithX:resolvedX y:resolvedY textContent:resolvedTextContent];
+	        }
+	        // If splitting is needed, create a parent layer and add sublayers for each text segment.
+	        CALayer *layer = [CALayer new];
+	        for (NSDictionary *item in splitItem)
+	        {
             CALayer *subLayer = [self newSubLayerWithX:[SVGLength svgLengthFromNSString:item[@"x"]]
                                                     y:[SVGLength svgLengthFromNSString:item[@"y"]]
                                           textContent:item[@"text"]];
             [layer addSublayer:subLayer];
         }
-        return layer;
-    }
-    
-    // If no position is specified, create a layer using the current X and Y values and the entire text content.
-    return [self newSubLayerWithX:self.x y:self.y textContent:self.textContent];
+	        return layer;
+	    }
+	    
+	    // If no position is specified, create a layer using the current X and Y values and the entire text content.
+	    return [self newSubLayerWithX:resolvedX y:resolvedY textContent:resolvedTextContent];
 }
 
 /// Helper method to return the string value or its formatted version if empty.


### PR DESCRIPTION
## Summary

  Fixes a text positioning issue where SVGKit renders text content from a single child tspan, but ignores that tspan's x/y attributes during
  layout.

  This improves compatibility with SVGs exported by tools like Fabric.js, which commonly emit text in the form:

```xml
<text ...>
  <tspan x="-50" y="15.71">Stage</tspan>
</text>
```

  ## Problem

  SVGKit currently gets text content via textContent, so child tspan text is rendered.

  But the positioning logic only reads x/y from the parent text element, not from a child tspan.

  As a result, SVGs that rely on a single child tspan for positioning render with visible offset compared to browser output.

  ## What changed

  This PR adds a narrow compatibility fallback:

  - when a text element contains exactly one element child
  - and that child is a tspan
  - use that tspan's x/y and textContent for rendering

  All other existing behavior remains unchanged.

  ## Scope

  Included:

  - single child tspan
  - x/y support for that tspan
  - textContent fallback from the child tspan

  Not included:

  - multiple tspan layout
  - dx/dy
  - tspan style overrides
  - full SVG text layout support

  ## Why this approach

  This is a small and low-risk fix for a common real-world export pattern.

  It avoids broad changes to the existing text layout behavior while addressing a clear compatibility issue.

  ## Example

  ### Input

```xml
<g transform="matrix(1 0 0 1 4746.95 5663.28)">
  <text font-size="50">
    <tspan x="-50" y="15.71">Stage</tspan>
  </text>
</g>
```

  ### Before

  - text content was rendered
  - child tspan x/y was ignored
  - text appeared shifted

  ### After

  - text content is rendered
  - child tspan x/y is used
  - placement is closer to browser rendering

  ## Testing

  Tested against SVGs exported by Fabric.js that use:

  - a parent text element
  - exactly one child tspan
  - positioning defined on the child tspan

  Verified that the rendered text moves from an incorrect offset to the expected position.

  ## Notes

  This PR is intended as a targeted bugfix, not full tspan support.

  A future follow-up could expand support for:

  - multiple tspan children
  - dx/dy
  - per-span styling
  - more complete text layout behavior